### PR TITLE
카카오 도서 검색 api 연동

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/controller/BookController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/controller/BookController.java
@@ -1,0 +1,34 @@
+package site.bookmore.bookmore.books.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.bookmore.bookmore.books.dto.BookResponse;
+import site.bookmore.bookmore.books.util.api.kakao.KakaoBookSearch;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchResponse;
+import site.bookmore.bookmore.common.dto.ResultResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/books")
+public class BookController {
+    private final KakaoBookSearch kakaoBookSearch;
+
+    // Todo. 카카오 api 의존도 해결
+    @GetMapping("")
+    public ResultResponse<Page<BookResponse>> search(KakaoSearchParams kakaoSearchParams) {
+        // 카카오 도서 검색 요청
+        KakaoSearchResponse response = kakaoBookSearch.search(kakaoSearchParams).block();
+        List<BookResponse> bookResponses = response.getDocuments().stream().map(BookResponse::of).collect(Collectors.toList());
+        Page<BookResponse> result = new PageImpl<>(bookResponses, Pageable.unpaged(), response.getMeta().getPageable_count());
+        return ResultResponse.success(result);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/KakaoBookSearch.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/KakaoBookSearch.java
@@ -1,0 +1,56 @@
+package site.bookmore.bookmore.books.util.api.kakao;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Mono;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchResponse;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Component
+public class KakaoBookSearch {
+    private static final String BASE_URL = "http://dapi.kakao.com";
+    private static final String SEARCH_ENDPOINT = "/v3/search/book";
+    private final String token;
+
+    private final WebClient webClient = WebClient.create(BASE_URL);
+
+    public KakaoBookSearch(@Value("${api.token.kakao}") String kakaoToken) {
+        this.token = kakaoToken;
+    }
+
+    // Todo. 타임아웃 시간 설정
+    public Mono<KakaoSearchResponse> search(KakaoSearchParams kakaoSearchParams) {
+        return webClient.get()
+                .uri(uriBuilder -> buildUri(uriBuilder, kakaoSearchParams))
+                .header(AUTHORIZATION, token)
+                .retrieve()
+                .bodyToMono(KakaoSearchResponse.class);
+    }
+
+    private URI buildUri(UriBuilder uriBuilder, KakaoSearchParams kakaoSearchParams) {
+        uriBuilder.path(SEARCH_ENDPOINT);
+        Class<?> clazz = kakaoSearchParams.getClass();
+        Method[] methods = clazz.getDeclaredMethods();
+
+        try {
+            for (Method method : methods) {
+                String name = method.getName();
+                if (!name.startsWith("get")) continue;
+                String fieldName = name.substring(3).toLowerCase();
+                Object value = method.invoke(kakaoSearchParams);
+                if (value != null) uriBuilder.queryParam(fieldName, value);
+            }
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            // InvocationTargetException : KakaoSearchParams 필드가 null인경우 api 호출시 제외됨
+        }
+        return uriBuilder.build();
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Document.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Document.java
@@ -1,11 +1,17 @@
 package site.bookmore.bookmore.books.util.api.kakao.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Document {
     private String title;
     private String contents;

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Document.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Document.java
@@ -1,0 +1,21 @@
+package site.bookmore.bookmore.books.util.api.kakao.dto;
+
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+public class Document {
+    private String title;
+    private String contents;
+    private String url;
+    private String isbn;
+    private OffsetDateTime datetime;
+    private List<String> authors;
+    private String publisher;
+    private List<String> translators;
+    private int price;
+    private String thumbnail;
+    private String status;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/KakaoSearchParams.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/KakaoSearchParams.java
@@ -1,0 +1,22 @@
+package site.bookmore.bookmore.books.util.api.kakao.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class KakaoSearchParams {
+    private final String query;
+    private final String sort;
+    private final Integer page;
+    private final Integer size;
+    private final String target;
+
+    @Builder
+    public KakaoSearchParams(String query, String sort, Integer page, Integer size, String target) {
+        this.query = query;
+        this.sort = sort;
+        this.page = page;
+        this.size = size;
+        this.target = target;
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/KakaoSearchResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/KakaoSearchResponse.java
@@ -1,10 +1,14 @@
 package site.bookmore.bookmore.books.util.api.kakao.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class KakaoSearchResponse {
     private Meta meta;
     private List<Document> documents;

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/KakaoSearchResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/KakaoSearchResponse.java
@@ -1,0 +1,11 @@
+package site.bookmore.bookmore.books.util.api.kakao.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class KakaoSearchResponse {
+    private Meta meta;
+    private List<Document> documents;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Meta.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Meta.java
@@ -1,8 +1,14 @@
 package site.bookmore.bookmore.books.util.api.kakao.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Meta {
     private long total_count;
     private long pageable_count;

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Meta.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Meta.java
@@ -1,0 +1,10 @@
+package site.bookmore.bookmore.books.util.api.kakao.dto;
+
+import lombok.Getter;
+
+@Getter
+public class Meta {
+    private long total_count;
+    private long pageable_count;
+    private boolean is_end;
+}

--- a/backend/src/test/java/site/bookmore/bookmore/books/controller/BookControllerTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/controller/BookControllerTest.java
@@ -1,0 +1,103 @@
+package site.bookmore.bookmore.books.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import reactor.core.publisher.Mono;
+import site.bookmore.bookmore.books.util.api.kakao.KakaoBookSearch;
+import site.bookmore.bookmore.books.util.api.kakao.dto.Document;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchResponse;
+import site.bookmore.bookmore.books.util.api.kakao.dto.Meta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BookController.class)
+class BookControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private KakaoBookSearch kakaoBookSearch;
+
+    private static final String SUCCESS = "SUCCESS";
+
+    @Test
+    @DisplayName("도서 리스트 검색 정상")
+    @WithMockUser
+    void search() throws Exception {
+        //given
+        List<Document> documents = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Document ele = Document.builder()
+                    .title("title" + i)
+                    .authors(List.of("authors"))
+                    .translators(List.of("translator"))
+                    .contents("contents" + 1)
+                    .isbn(String.valueOf(i))
+                    .price(10000)
+                    .url("http://test.com/" + i)
+                    .build();
+            documents.add(ele);
+        }
+        Meta meta = Meta.builder()
+                .pageable_count(18)
+                .total_count(20)
+                .is_end(false)
+                .build();
+
+        KakaoSearchResponse kakaoSearchResponse = new KakaoSearchResponse(meta, documents);
+
+        given(kakaoBookSearch.search(any(KakaoSearchParams.class))).willReturn(Mono.just(kakaoSearchResponse));
+
+        mockMvc.perform(get("/api/v1/books?query=정의란 무엇인가")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value(SUCCESS))
+                .andExpect(jsonPath("$.result.content").isArray())
+                .andExpect(jsonPath("$.result.totalElements").value(meta.getPageable_count()));
+
+        verify(kakaoBookSearch).search(any(KakaoSearchParams.class));
+    }
+
+    @Test
+    @DisplayName("도서 리스트 검색 - 검색 결과 없음")
+    @WithMockUser
+    void search_documents_empty() throws Exception {
+        //given
+        List<Document> documents = new ArrayList<>();
+        Meta meta = Meta.builder()
+                .pageable_count(0)
+                .total_count(0)
+                .is_end(true)
+                .build();
+
+        KakaoSearchResponse kakaoSearchResponse = new KakaoSearchResponse(meta, documents);
+
+        given(kakaoBookSearch.search(any(KakaoSearchParams.class))).willReturn(Mono.just(kakaoSearchResponse));
+
+        mockMvc.perform(get("/api/v1/books?query=책이름")
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value(SUCCESS))
+                .andExpect(jsonPath("$.result.content").isArray())
+                .andExpect(jsonPath("$.result.totalElements").value(meta.getPageable_count()));
+
+        verify(kakaoBookSearch).search(any(KakaoSearchParams.class));
+    }
+}


### PR DESCRIPTION
## 개요

카카오 도서 검색 api 연동

## 작업 내용

- 카카오 도서 검색 api 연동하였습니다.
- 현재 도서 검색 후 페이지 객체로 변환하여 반환해주도록한 상태입니다.
- 카카오 api 의존도 문제 해결과 타임아웃 설정은 아직 해두지 않았습니다.

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과

## Merge 전 체크리스트

- [ ] 환경변수에 카카오 apikey 추가가 필요합니다. 자세한 내용은 슬랙을 통해 전파하겠습니다.