### PR TITLE
도서 리뷰 등록 / 좋아요 | 취소

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
@@ -1,0 +1,23 @@
+package site.bookmore.bookmore.books.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import site.bookmore.bookmore.books.dto.ReviewRequest;
+import site.bookmore.bookmore.books.dto.ReviewResponse;
+import site.bookmore.bookmore.books.service.ReviewService;
+import site.bookmore.bookmore.common.dto.ResultResponse;
+
+@RestController
+@RequestMapping("/api/v1/books")
+@RequiredArgsConstructor
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    @PostMapping("/{isbn}/reviews")
+    public ResultResponse<ReviewResponse> create(@RequestBody ReviewRequest reviewRequest, @PathVariable String isbn, Authentication authentication) {
+        String email = authentication.getName();
+        Long id = reviewService.create(reviewRequest, isbn, email);
+        return ResultResponse.success(new ReviewResponse(id, "리뷰 등록 완료"));
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
@@ -14,10 +14,19 @@ import site.bookmore.bookmore.common.dto.ResultResponse;
 public class ReviewController {
     private final ReviewService reviewService;
 
+    // 도서 리뷰 등록
     @PostMapping("/{isbn}/reviews")
     public ResultResponse<ReviewResponse> create(@RequestBody ReviewRequest reviewRequest, @PathVariable String isbn, Authentication authentication) {
         String email = authentication.getName();
         Long id = reviewService.create(reviewRequest, isbn, email);
         return ResultResponse.success(new ReviewResponse(id, "리뷰 등록 완료"));
+    }
+
+    // 도서 리뷰에 좋아요 | 취소
+    @PostMapping("/reviews/{id}/likes")
+    public ResultResponse<String> likes(@PathVariable Long id, Authentication authentication) {
+        String email = authentication.getName();
+        boolean result = reviewService.doLikes(email, id);
+        return ResultResponse.success(result ? "좋아요를 눌렀습니다." : "좋아요가 취소되었습니다.");
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
@@ -1,0 +1,33 @@
+package site.bookmore.bookmore.books.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.entity.Review;
+import site.bookmore.bookmore.users.entity.User;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ReviewRequest {
+    private String body;
+    private boolean spoiler;
+    private int professionalism;
+    private int fun;
+    private int readability;
+    private int collectible;
+    private int difficulty;
+
+    public Review toEntity(User user, Book book) {
+        return Review.builder()
+                .body(body)
+                .spoiler(spoiler)
+                .professionalism(professionalism)
+                .fun(fun)
+                .readability(readability)
+                .collectible(collectible)
+                .difficulty(difficulty)
+                .build();
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
@@ -21,6 +21,8 @@ public class ReviewRequest {
 
     public Review toEntity(User user, Book book) {
         return Review.builder()
+                .author(user)
+                .book(book)
                 .body(body)
                 .spoiler(spoiler)
                 .professionalism(professionalism)
@@ -28,6 +30,7 @@ public class ReviewRequest {
                 .readability(readability)
                 .collectible(collectible)
                 .difficulty(difficulty)
+                .likesCount(0)
                 .build();
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewResponse.java
@@ -1,0 +1,13 @@
+package site.bookmore.bookmore.books.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ReviewResponse {
+    private Long id;
+    private String message;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Book.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Book.java
@@ -1,6 +1,9 @@
 package site.bookmore.bookmore.books.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -13,6 +16,9 @@ import java.util.List;
 @Getter
 @Table(name = "books")
 @EntityListeners(AuditingEntityListener.class)
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Book {
     @Id
     private String id;
@@ -20,9 +26,11 @@ public class Book {
     @Column(nullable = false)
     private String title;
 
+    @Builder.Default
     @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST})
     private List<Author> authors = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST})
     private List<Translator> translators = new ArrayList<>();
 

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Likes.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Likes.java
@@ -1,0 +1,52 @@
+package site.bookmore.bookmore.books.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import site.bookmore.bookmore.common.entity.BaseEntity;
+import site.bookmore.bookmore.users.entity.User;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "likes")
+public class Likes extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean liked;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public static Likes of(User user, Review review) {
+        return Likes.builder()
+                .user(user)
+                .review(review)
+                .build();
+    }
+
+    public boolean likes() {
+        if (liked) {
+            review.unlikes();
+        } else review.likes();
+
+        toggleLikes();
+        return liked;
+    }
+
+    private void toggleLikes() {
+        liked = !liked;
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Review.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Review.java
@@ -1,0 +1,37 @@
+package site.bookmore.bookmore.books.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.bookmore.bookmore.common.entity.BaseEntity;
+import site.bookmore.bookmore.users.entity.User;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "reviews")
+public class Review extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private User author;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Book book;
+
+    private String body;
+    private boolean spoiler;
+    private int professionalism;
+    private int fun;
+    private int readability;
+    private int collectible;
+    private int difficulty;
+    private int likesCount;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Review.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Review.java
@@ -34,4 +34,14 @@ public class Review extends BaseEntity {
     private int collectible;
     private int difficulty;
     private int likesCount;
+
+    public synchronized void likes() {
+        likesCount++;
+    }
+
+    public synchronized void unlikes() {
+        if (likesCount > 0) {
+            likesCount--;
+        }
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/repository/LikesRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/repository/LikesRepository.java
@@ -1,0 +1,12 @@
+package site.bookmore.bookmore.books.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.bookmore.bookmore.books.entity.Likes;
+import site.bookmore.bookmore.books.entity.Review;
+import site.bookmore.bookmore.users.entity.User;
+
+import java.util.Optional;
+
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+    Optional<Likes> findByUserAndReview(User user, Review review);
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package site.bookmore.bookmore.books.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.bookmore.bookmore.books.entity.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -7,8 +7,8 @@ import site.bookmore.bookmore.books.entity.Book;
 import site.bookmore.bookmore.books.entity.Review;
 import site.bookmore.bookmore.books.repository.BookRepository;
 import site.bookmore.bookmore.books.repository.ReviewRepository;
-import site.bookmore.bookmore.common.exception.AbstractAppException;
-import site.bookmore.bookmore.common.exception.ErrorCode;
+import site.bookmore.bookmore.common.exception.not_found.BookNotFoundException;
+import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
 import site.bookmore.bookmore.users.entity.User;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
 
@@ -23,15 +23,15 @@ public class ReviewService {
     // 도서 리뷰 등록
     public Long create(ReviewRequest reviewRequest, String isbn, String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new AbstractAppException(ErrorCode.EMAIL_NOT_FOUND) {
-                });
+                .orElseThrow(UserNotFoundException::new);
 
         Book book = bookRepository.findById(isbn)
-                .orElseThrow(() -> new AbstractAppException(ErrorCode.BOOK_NOT_FOUND) {
-                });
+                .orElseThrow(BookNotFoundException::new);
 
         Review review = reviewRequest.toEntity(user, book);
         Review savedReview = reviewRepository.save(review);
+
+        // 나의 팔로잉이 리뷰를 등록했을 때의 알림 발생 추가해야 함
 
         return savedReview.getId();
     }

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -1,0 +1,38 @@
+package site.bookmore.bookmore.books.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.bookmore.bookmore.books.dto.ReviewRequest;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.entity.Review;
+import site.bookmore.bookmore.books.repository.BookRepository;
+import site.bookmore.bookmore.books.repository.ReviewRepository;
+import site.bookmore.bookmore.common.exception.AbstractAppException;
+import site.bookmore.bookmore.common.exception.ErrorCode;
+import site.bookmore.bookmore.users.entity.User;
+import site.bookmore.bookmore.users.repositroy.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final BookRepository bookRepository;
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+
+    // 도서 리뷰 등록
+    public Long create(ReviewRequest reviewRequest, String isbn, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new AbstractAppException(ErrorCode.EMAIL_NOT_FOUND) {
+                });
+
+        Book book = bookRepository.findById(isbn)
+                .orElseThrow(() -> new AbstractAppException(ErrorCode.BOOK_NOT_FOUND) {
+                });
+
+        Review review = reviewRequest.toEntity(user, book);
+        Review savedReview = reviewRepository.save(review);
+
+        return savedReview.getId();
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.bookmore.bookmore.books.dto.ReviewRequest;
 import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.entity.Likes;
 import site.bookmore.bookmore.books.entity.Review;
 import site.bookmore.bookmore.books.repository.BookRepository;
+import site.bookmore.bookmore.books.repository.LikesRepository;
 import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.not_found.BookNotFoundException;
+import site.bookmore.bookmore.common.exception.not_found.ReviewNotFoundException;
 import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
 import site.bookmore.bookmore.users.entity.User;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
@@ -17,6 +20,8 @@ import site.bookmore.bookmore.users.repositroy.UserRepository;
 public class ReviewService {
 
     private final BookRepository bookRepository;
+    private final LikesRepository likesRepository;
+
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
 
@@ -34,5 +39,25 @@ public class ReviewService {
         // 나의 팔로잉이 리뷰를 등록했을 때의 알림 발생 추가해야 함
 
         return savedReview.getId();
+    }
+
+    // 도서 리뷰에 좋아요 | 취소
+    public boolean doLikes(String email, Long reviewId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewNotFoundException::new);
+
+        Likes likes = likesRepository.findByUserAndReview(user, review)
+                .orElse(Likes.of(user, review));
+
+        boolean result = likes.likes();
+
+        likesRepository.save(likes);
+
+        // 내가 작성한 리뷰에 좋아요가 달렸을 때의 알림 발생 추가해야 함
+
+        return result;
     }
 }

--- a/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
@@ -12,13 +12,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import site.bookmore.bookmore.books.dto.ReviewRequest;
 import site.bookmore.bookmore.books.service.ReviewService;
 
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 
 @WebMvcTest(ReviewController.class)
 class ReviewControllerTest {
@@ -41,7 +41,7 @@ class ReviewControllerTest {
         ReviewRequest reviewRequest = new ReviewRequest("body", false, 5, 5, 5, 5, 5);
 
         // when
-        when(reviewService.create(reviewRequest, "9791158393083", "wkdtjgus0319@naver.com"))
+        when(reviewService.create(any(ReviewRequest.class), eq("9791158393083"), anyString()))
                 .thenReturn(1L);
 
         // then
@@ -49,9 +49,11 @@ class ReviewControllerTest {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(reviewRequest)))
-                .andDo(print())
-                .andExpect(jsonPath("$.result.id").exists())
-                .andExpect(jsonPath("$.result.message").exists())
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("SUCCESS"))
+                .andExpect(jsonPath("$.result.id").value(1))
+                .andExpect(jsonPath("$.result.message").value("리뷰 등록 완료"));
+
+        verify(reviewService).create(any(ReviewRequest.class), eq("9791158393083"), anyString());
     }
 }

--- a/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
@@ -56,4 +56,41 @@ class ReviewControllerTest {
 
         verify(reviewService).create(any(ReviewRequest.class), eq("9791158393083"), anyString());
     }
+
+    /* ========== 도서 리뷰 좋아요 | 취소 ========== */
+    @Test
+    @DisplayName("도서 리뷰 좋아요 성공")
+    @WithMockUser
+    void doLikes_success() throws Exception {
+        // when
+        when(reviewService.doLikes(anyString(), eq(1L)))
+                .thenReturn(true);
+
+        // then
+        mockMvc.perform(post("/api/v1/books/reviews/1/likes")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("SUCCESS"))
+                .andExpect(jsonPath("$.result").value("좋아요를 눌렀습니다."));
+
+        verify(reviewService).doLikes(anyString(), eq(1L));
+    }
+
+    @Test
+    @DisplayName("도서 리뷰 좋아요 취소 성공")
+    @WithMockUser
+    void doLikes_cancel_success() throws Exception {
+        // when
+        when(reviewService.doLikes(anyString(), eq(1L)))
+                .thenReturn(false);
+
+        // then
+        mockMvc.perform(post("/api/v1/books/reviews/1/likes")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("SUCCESS"))
+                .andExpect(jsonPath("$.result").value("좋아요가 취소되었습니다."));
+
+        verify(reviewService).doLikes(anyString(), eq(1L));
+    }
 }

--- a/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
@@ -1,0 +1,57 @@
+package site.bookmore.bookmore.books.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import site.bookmore.bookmore.books.dto.ReviewRequest;
+import site.bookmore.bookmore.books.service.ReviewService;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(ReviewController.class)
+class ReviewControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    ReviewService reviewService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    /* ========== 도서 리뷰 등록 ========== */
+    @Test
+    @DisplayName("도서 리뷰 등록 성공")
+    @WithMockUser
+    void create_success() throws Exception {
+        // given
+        ReviewRequest reviewRequest = new ReviewRequest("body", false, 5, 5, 5, 5, 5);
+
+        // when
+        when(reviewService.create(reviewRequest, "9791158393083", "wkdtjgus0319@naver.com"))
+                .thenReturn(1L);
+
+        // then
+        mockMvc.perform(post("/api/v1/books/9791158393083/reviews")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(reviewRequest)))
+                .andDo(print())
+                .andExpect(jsonPath("$.result.id").exists())
+                .andExpect(jsonPath("$.result.message").exists())
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/site/bookmore/bookmore/books/service/ReviewServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/service/ReviewServiceTest.java
@@ -1,0 +1,84 @@
+package site.bookmore.bookmore.books.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import site.bookmore.bookmore.books.dto.ReviewRequest;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.entity.Review;
+import site.bookmore.bookmore.books.repository.BookRepository;
+import site.bookmore.bookmore.books.repository.ReviewRepository;
+import site.bookmore.bookmore.common.exception.AbstractAppException;
+import site.bookmore.bookmore.common.exception.ErrorCode;
+import site.bookmore.bookmore.users.entity.User;
+import site.bookmore.bookmore.users.repositroy.UserRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ReviewServiceTest {
+
+    private final BookRepository bookRepository = Mockito.mock(BookRepository.class);
+    private final ReviewRepository reviewRepository = Mockito.mock(ReviewRepository.class);
+    private final UserRepository userRepository = Mockito.mock(UserRepository.class);
+    private final ReviewService reviewService = new ReviewService(bookRepository, reviewRepository, userRepository);
+
+    /* ========== 도서 리뷰 등록 ========== */
+    private final User user = User.builder()
+            .email("email")
+            .build();
+
+    private final Book book = Book.builder()
+            .id("isbn")
+            .build();
+
+    private final Review review = Review.builder()
+            .author(user)
+            .book(book)
+            .build();
+
+    @Test
+    @DisplayName("도서 리뷰 등록 성공")
+    void create_success() {
+        when(userRepository.findByEmail(user.getEmail()))
+                .thenReturn(Optional.of(user));
+        when(bookRepository.findById(book.getId()))
+                .thenReturn(Optional.of(book));
+        when(reviewRepository.save(any(Review.class)))
+                .thenReturn(review);
+
+        Assertions.assertDoesNotThrow(() -> reviewService.create(new ReviewRequest(), book.getId(), user.getEmail()));
+    }
+
+    @Test
+    @DisplayName("도서 리뷰 등록 실패 - 유저 정보가 없는 경우")
+    void create_user_not_found() {
+        when(userRepository.findByEmail(user.getEmail()))
+                .thenReturn(Optional.empty());
+        when(bookRepository.findById(book.getId()))
+                .thenReturn(Optional.of(book));
+        when(reviewRepository.save(any(Review.class)))
+                .thenReturn(review);
+
+        AbstractAppException abstractAppException = Assertions.assertThrows(AbstractAppException.class, () -> reviewService.create(new ReviewRequest(), book.getId(), user.getEmail()));
+        assertEquals(ErrorCode.USER_NOT_FOUND, abstractAppException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("도서 리뷰 등록 실패 - 책 정보가 없는 경우")
+    void create_book_not_found() {
+        when(userRepository.findByEmail(user.getEmail()))
+                .thenReturn(Optional.of(user));
+        when(bookRepository.findById(book.getId()))
+                .thenReturn(Optional.empty());
+        when(reviewRepository.save(any(Review.class)))
+                .thenReturn(review);
+
+        AbstractAppException abstractAppException = Assertions.assertThrows(AbstractAppException.class, () -> reviewService.create(new ReviewRequest(), book.getId(), user.getEmail()));
+        assertEquals(ErrorCode.BOOK_NOT_FOUND, abstractAppException.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 개요

도서 리뷰 등록 기능 개발
도서 리뷰 좋아요 | 취소 기능 개발

## 작업 내용

- 유저 정보 확인 -> 책 유무 확인 -> 리뷰를 작성할 수 있도록 기능을 구현했습니다.
- 좋아요를 누르면 Review의 likesCount가 +1 되고, 두 번 누르면 '좋아요'가 취소되도록 구현했습니다.

## 리뷰 필요

- ServiceTest 구현을 위해 민우님이 만드신 Book Entity에 Builder 어노테이션을 추가했습니다.
- ReviewService에 알림 기능을 추가해야합니다. (나의 팔로잉이 리뷰를 등록했을 때의 알림, 내가 작성한 리뷰에 좋아요가 달렸을 때의 알림)
- Authentication에서 아이디로 사용되는 이메일을 가져오기 위해 추가 변경 사항이 필요할 듯 합니다.

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과