### PR TITLE
팔로우 기능 수정

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/ErrorCode.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
     API_REQUEST_TIMEOUT(REQUEST_TIMEOUT, "요청 시간이 초과되었습니다."),
     DUPLICATED_NICKNAME(CONFLICT, "이미 사용중인 닉네임입니다."),
     DUPLICATED_EMAIL(CONFLICT, "이미 사용중인 이메일입니다."),
+    DUPLICATED_FOLLOW(CONFLICT, "이미 팔로우 중입니다."),
+    DUPLICATED_UNFOLLOW(CONFLICT, "이미 언팔로우 중입니다."),
     FOLLOW_NOT_ME(BAD_REQUEST, "나를 팔로우 할 수 없습니다."),
     DATABASE_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 에러");
 

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/conflict/DuplicateFollowException.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/conflict/DuplicateFollowException.java
@@ -1,0 +1,11 @@
+package site.bookmore.bookmore.common.exception.conflict;
+
+import site.bookmore.bookmore.common.exception.AbstractAppException;
+
+import static site.bookmore.bookmore.common.exception.ErrorCode.DUPLICATED_FOLLOW;
+
+public class DuplicateFollowException extends AbstractAppException {
+    public DuplicateFollowException() {
+        super(DUPLICATED_FOLLOW);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/conflict/DuplicateUnfollowException.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/conflict/DuplicateUnfollowException.java
@@ -1,0 +1,11 @@
+package site.bookmore.bookmore.common.exception.conflict;
+
+import site.bookmore.bookmore.common.exception.AbstractAppException;
+
+import static site.bookmore.bookmore.common.exception.ErrorCode.DUPLICATED_UNFOLLOW;
+
+public class DuplicateUnfollowException extends AbstractAppException {
+    public DuplicateUnfollowException() {
+        super(DUPLICATED_UNFOLLOW);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/users/controller/FollowController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/controller/FollowController.java
@@ -10,8 +10,6 @@ import site.bookmore.bookmore.users.dto.FollowerResponse;
 import site.bookmore.bookmore.users.dto.FollowingResponse;
 import site.bookmore.bookmore.users.service.FollowService;
 
-import java.security.Principal;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -20,7 +18,7 @@ public class FollowController {
     private final FollowService followService;
 
     @PostMapping("/{id}/follow")
-    public ResultResponse<String> following(@PathVariable Long id, Authentication authentication, Principal principal) {
+    public ResultResponse<String> following(@PathVariable Long id, Authentication authentication) {
         String email = authentication.getName();
         return ResultResponse.success(followService.following(id, email));
     }

--- a/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
@@ -1,5 +1,7 @@
 package site.bookmore.bookmore.users.repositroy;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.bookmore.bookmore.users.entity.Follow;
 import site.bookmore.bookmore.users.entity.User;
@@ -8,4 +10,10 @@ import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFollowerAndFollowing(User follower, User following);
+
+    Optional<Follow> findByFollowerAndFollowingAndDeletedDatetimeIsNull(User follower, User following);
+
+    Page<Follow> findByFollowerAndDeletedDatetimeIsNull(Pageable pageable, User follower);
+
+    Page<Follow> findByFollowingAndDeletedDatetimeIsNull(Pageable pageable, User following);
 }


### PR DESCRIPTION
## 개요

- 팔로우 기능 수정

## 작업 내용

1. 팔로우
   - 이미 팔로우 한 경우에 두 번 연속으로 못하도록 예외 추가
   - 언팔로우하고 다시 팔로우 하는 경우 예외 추가(컬럼이 있어도 deletedDatetime이 null이 아닌 경우에 팔로우 가능)

2. 언팔로우
   - deletedDatetime이 null이 아닌 경우 (언팔로우를 이미 한 경우) 에 다시 못하도록 예외 추가
   
3. 팔로워/팔로잉 조회
   - 팔로잉 조회: 팔로잉 한 사람만 보일 수 있도록 예외 추가
   - 팔로워 조회: 팔로워 한 사람만 보일 수 있도록 예외 추가

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과

## 주안점(optional)

- 예외 상황이 모두 잘 처리 되는지 확인 부탁드립니다.

## Merge 전 체크리스트(optional)

- [ ] 팔로우 두 번 이상 해보기
- [ ] 내 자신 팔로우 해보기
- [ ] 언팔로우 하고 팔로우 다시 하기
- [ ] 언팔로우 두 번 이상 해보기
- [ ] 팔로우 하지 않은 사람 언팔로우 해보기