### PR TITLE
리뷰 등록 알림 기능 추가

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -12,7 +12,6 @@ import site.bookmore.bookmore.books.repository.BookRepository;
 import site.bookmore.bookmore.books.repository.LikesRepository;
 import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.not_found.BookNotFoundException;
-import site.bookmore.bookmore.common.exception.not_found.FollowNotFoundException;
 import site.bookmore.bookmore.common.exception.not_found.ReviewNotFoundException;
 import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
 import site.bookmore.bookmore.observer.event.alarm.AlarmCreate;

--- a/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
@@ -1,11 +1,22 @@
 package site.bookmore.bookmore.users.repositroy;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.bookmore.bookmore.users.entity.Follow;
 import site.bookmore.bookmore.users.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFollowerAndFollowing(User follower, User following);
+
+    Optional<Follow> findByFollowerAndFollowingAndDeletedDatetimeIsNull(User follower, User following);
+
+    Page<Follow> findByFollowerAndDeletedDatetimeIsNull(Pageable pageable, User follower);
+
+    Page<Follow> findByFollowingAndDeletedDatetimeIsNull(Pageable pageable, User following);
+
+    List<Follow> findAllByFollowingAndDeletedDatetimeIsNull(User following);
 }

--- a/backend/src/test/java/site/bookmore/bookmore/books/service/ReviewServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/service/ReviewServiceTest.java
@@ -15,6 +15,7 @@ import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.AbstractAppException;
 import site.bookmore.bookmore.common.exception.ErrorCode;
 import site.bookmore.bookmore.users.entity.User;
+import site.bookmore.bookmore.users.repositroy.FollowRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
 
 import java.util.Optional;
@@ -26,11 +27,12 @@ import static org.mockito.Mockito.when;
 class ReviewServiceTest {
 
     private final BookRepository bookRepository = Mockito.mock(BookRepository.class);
+    private final FollowRepository followRepository = Mockito.mock(FollowRepository.class);
     private final LikesRepository likesRepository = Mockito.mock(LikesRepository.class);
     private final ReviewRepository reviewRepository = Mockito.mock(ReviewRepository.class);
     private final UserRepository userRepository = Mockito.mock(UserRepository.class);
     private final ApplicationEventPublisher publisher = Mockito.mock(ApplicationEventPublisher.class);
-    private final ReviewService reviewService = new ReviewService(bookRepository, likesRepository, reviewRepository, userRepository, publisher);
+    private final ReviewService reviewService = new ReviewService(bookRepository, followRepository, likesRepository, reviewRepository, userRepository, publisher);
 
     private final User user = User.builder()
             .email("email")


### PR DESCRIPTION
## 개요

내가 팔로잉하는 사람이 도서 리뷰를 등록하면 내가 알림을 받는 기능 구현

## 작업 내용

리뷰가 작성될 때, Follower Repo에서 리뷰 작성자로 Follower 객체를 리스트로 가져와서
for문으로 각 follower(User 객체)를 가져와 알림을 발생시켰습니다.

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [ ] 테스트 코드 작성 및 통과

## 주안점

포스트맨으로 테스트한 결과 팔로워가 여럿이어도 알림이 잘 발생합니다.
그러나 for문을 사용했기에 효율성 측면에서 어떨지 모르겠습니다. 

리뷰 부탁드립니다!