### PR TITLE
도서 리뷰: review & chart로 DB 테이블 분리

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.entity.Chart;
 import site.bookmore.bookmore.books.entity.Review;
 import site.bookmore.bookmore.users.entity.User;
 
@@ -13,11 +14,7 @@ import site.bookmore.bookmore.users.entity.User;
 public class ReviewRequest {
     private String body;
     private boolean spoiler;
-    private int professionalism;
-    private int fun;
-    private int readability;
-    private int collectible;
-    private int difficulty;
+    private Chart chart;
 
     public Review toEntity(User user, Book book) {
         return Review.builder()
@@ -25,11 +22,13 @@ public class ReviewRequest {
                 .book(book)
                 .body(body)
                 .spoiler(spoiler)
-                .professionalism(professionalism)
-                .fun(fun)
-                .readability(readability)
-                .collectible(collectible)
-                .difficulty(difficulty)
+                .chart(Chart.builder()
+                        .professionalism(chart.getProfessionalism())
+                        .fun(chart.getFun())
+                        .readability(chart.getReadability())
+                        .collectible(chart.getCollectible())
+                        .difficulty(chart.getDifficulty())
+                        .build())
                 .likesCount(0)
                 .build();
     }

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Chart.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Chart.java
@@ -1,0 +1,27 @@
+package site.bookmore.bookmore.books.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Chart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int professionalism;
+    private int fun;
+    private int readability;
+    private int collectible;
+    private int difficulty;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Review.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Review.java
@@ -27,11 +27,11 @@ public class Review extends BaseEntity {
 
     private String body;
     private boolean spoiler;
-    private int professionalism;
-    private int fun;
-    private int readability;
-    private int collectible;
-    private int difficulty;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "chart_id")
+    private Chart chart;
+
     private int likesCount;
 
     public synchronized void likes() {

--- a/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import site.bookmore.bookmore.books.dto.ReviewRequest;
+import site.bookmore.bookmore.books.entity.Chart;
 import site.bookmore.bookmore.books.service.ReviewService;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -38,7 +39,7 @@ class ReviewControllerTest {
     @WithMockUser
     void create_success() throws Exception {
         // given
-        ReviewRequest reviewRequest = new ReviewRequest("body", false, 5, 5, 5, 5, 5);
+        ReviewRequest reviewRequest = new ReviewRequest("body", false, Chart.builder().build());
 
         // when
         when(reviewService.create(any(ReviewRequest.class), eq("9791158393083"), anyString()))


### PR DESCRIPTION
## 개요

리뷰 테이블과 차트 테이블로 분리

## 작업 내용

기존 Review 테이블에 도서 평가 항목(5가지)이 모두 들어있어서 컬럼이 많고 보기에도 복잡해서 분리하기로 결정했습니다.

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거

## 주안점

기존에 짜놨던 리뷰 등록 성공 ServiceTest가 실패합니다. 추후에 수정 예정입니다.