### PR TITLE
도서 상세 조회 구현

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/controller/BookController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/controller/BookController.java
@@ -2,33 +2,29 @@ package site.bookmore.bookmore.books.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.bookmore.bookmore.books.dto.BookResponse;
-import site.bookmore.bookmore.books.util.api.kakao.KakaoBookSearch;
+import site.bookmore.bookmore.books.service.BookService;
 import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
-import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchResponse;
 import site.bookmore.bookmore.common.dto.ResultResponse;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/books")
 public class BookController {
-    private final KakaoBookSearch kakaoBookSearch;
+    private final BookService bookService;
 
-    // Todo. 카카오 api 의존도 해결
     @GetMapping("")
     public ResultResponse<Page<BookResponse>> search(KakaoSearchParams kakaoSearchParams) {
         // 카카오 도서 검색 요청
-        KakaoSearchResponse response = kakaoBookSearch.search(kakaoSearchParams).block();
-        List<BookResponse> bookResponses = response.getDocuments().stream().map(BookResponse::of).collect(Collectors.toList());
-        Page<BookResponse> result = new PageImpl<>(bookResponses, Pageable.unpaged(), response.getMeta().getPageable_count());
-        return ResultResponse.success(result);
+        return ResultResponse.success(bookService.searchAtKakao(kakaoSearchParams));
+    }
+
+    @GetMapping("/{isbn}")
+    public ResultResponse<BookResponse> searchByISBN(@PathVariable String isbn) {
+        return ResultResponse.success(bookService.searchByISBN(isbn));
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/BookResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/BookResponse.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import site.bookmore.bookmore.books.util.api.kakao.dto.Document;
+import site.bookmore.bookmore.books.entity.Subject;
 
 import java.util.List;
 
@@ -20,20 +20,11 @@ public class BookResponse {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<String> translators;
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String kdc;
+    private Subject subject;
     private String publisher;
+    private Integer pages;
     private String image;
+    private String chapter;
+    private String introduce;
     private int price;
-
-    public static BookResponse of(Document kakaoDocument){
-        return BookResponse.builder()
-                .isbn(kakaoDocument.getIsbn())
-                .title(kakaoDocument.getTitle())
-                .authors(kakaoDocument.getAuthors())
-                .translators(kakaoDocument.getTranslators())
-                .publisher(kakaoDocument.getPublisher())
-                .image(kakaoDocument.getThumbnail())
-                .price(kakaoDocument.getPrice())
-                .build();
-    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Author.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Author.java
@@ -1,12 +1,18 @@
 package site.bookmore.bookmore.books.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-@Entity
 @Getter
-@Table(name = "book_author")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "book_author", uniqueConstraints = {@UniqueConstraint(name = "idx_name_book", columnNames = {"name", "book_id"})})
 public class Author {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,6 +21,17 @@ public class Author {
     @Column(nullable = false)
     private String name;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Book book;
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public static Author of(String name, Book book) {
+        return Author.builder()
+                .name(name)
+                .book(book)
+                .build();
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Book.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Book.java
@@ -9,15 +9,15 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
-@Entity
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Book {
     @Id
     private String id;
@@ -26,35 +26,54 @@ public class Book {
     private String title;
 
     @Builder.Default
-    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST})
-    private List<Author> authors = new ArrayList<>();
+    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = {CascadeType.MERGE})
+    private Set<Author> authors = new HashSet<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST})
-    private List<Translator> translators = new ArrayList<>();
+    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = {CascadeType.MERGE})
+    private Set<Translator> translators = new HashSet<>();
 
-    @Column(nullable = false)
-    private String kdc;
+    private Subject subject;
 
-    @Column(nullable = false)
     private String publisher;
 
-    private int pages;
+    private Integer pages;
 
     private String image;
 
-    @Column(nullable = false)
     private String chapter;
 
-    @Column(nullable = false)
+    @Column(length = 300)
     private String introduce;
 
-    @Column(nullable = false)
-    private String summary;
+    private int price;
 
     @Column(nullable = false)
-    private int price;
+    private boolean cached;
 
     @CreatedDate
     private LocalDateTime createdDatetime;
+
+    public Book merge(Book book) {
+        if (id == null) id = book.getId();
+        if (title == null) title = book.getTitle();
+        if (authors.isEmpty()) authors = book.getAuthors();
+        if (translators.isEmpty()) translators = book.getTranslators();
+        if (subject == null) subject = book.getSubject();
+        if (publisher == null) publisher = book.getPublisher();
+        if (pages == null) pages = book.getPages();
+        if (image == null) image = book.getImage();
+        if (chapter == null) chapter = book.getChapter();
+        if (introduce == null) introduce = book.getIntroduce();
+        if (price == 0) price = book.getPrice();
+        return this;
+    }
+
+    public void addAuthors(Set<Author> authors) {
+        this.authors.addAll(authors);
+    }
+
+    public void addTranslators(Set<Translator> translators) {
+        this.translators.addAll(translators);
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Subject.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Subject.java
@@ -1,0 +1,27 @@
+package site.bookmore.bookmore.books.entity;
+
+public enum Subject {
+    총류("0"),
+    철학("1"),
+    종교("2"),
+    사회과학("3"),
+    순수과학("4"),
+    기술과학("5"),
+    예술("6"),
+    언어("7"),
+    문학("8"),
+    역사("9");
+
+    private final String code;
+
+    Subject(String code) {
+        this.code = code;
+    }
+
+    public static Subject of(String code) {
+        for (Subject subject : Subject.values()) {
+            if (subject.code.equals(code)) return subject;
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/entity/Translator.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/entity/Translator.java
@@ -1,11 +1,14 @@
 package site.bookmore.bookmore.books.entity;
 
-import lombok.Getter;
+import lombok.*;
 
 import javax.persistence.*;
 
-@Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
 @Table(name = "book_translator")
 public class Translator {
     @Id
@@ -15,6 +18,17 @@ public class Translator {
     @Column(nullable = false)
     private String name;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Book book;
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public static Translator of(String name, Book book) {
+        return Translator.builder()
+                .name(name)
+                .book(book)
+                .build();
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/repository/BookRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/repository/BookRepository.java
@@ -1,7 +1,13 @@
 package site.bookmore.bookmore.books.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import site.bookmore.bookmore.books.entity.Book;
 
+import java.util.Optional;
+
 public interface BookRepository extends JpaRepository<Book, String> {
+    @Query("SELECT b FROM Book b JOIN FETCH b.authors JOIN FETCH  b.translators WHERE b.id=:isbn")
+    Optional<Book> findById(@Param("isbn") String isbn);
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/BookService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/BookService.java
@@ -48,7 +48,11 @@ public class BookService {
         timer.start();
 
         Optional<Book> bookOptional = bookRepository.findById(isbn);
-        if (bookOptional.isPresent()) return BookResponseMapper.of(bookOptional.get());
+        if (bookOptional.isPresent()) {
+            timer.stop();
+            log.info("총 응답 시간 : {}ms", timer.getTotalTimeMillis());
+            return BookResponseMapper.of(bookOptional.get());
+        };
 
         log.info("DB 내 도서 정보 없음");
         log.info("API 호출");

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/BookService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/BookService.java
@@ -1,0 +1,73 @@
+package site.bookmore.bookmore.books.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StopWatch;
+import reactor.core.publisher.Mono;
+import site.bookmore.bookmore.books.dto.BookResponse;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.repository.BookRepository;
+import site.bookmore.bookmore.books.util.api.kakao.KakaoBookSearch;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchResponse;
+import site.bookmore.bookmore.books.util.api.kolis.KolisBookSearch;
+import site.bookmore.bookmore.books.util.mapper.BookResponseMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookService {
+    private final BookRepository bookRepository;
+    private final KakaoBookSearch kakaoBookSearch;
+    private final KolisBookSearch kolisBookSearch;
+
+    public Page<BookResponse> searchAtKakao(KakaoSearchParams kakaoSearchParams) {
+        // Todo. 카카오 api 의존도 해결
+        KakaoSearchResponse response = kakaoBookSearch.search(kakaoSearchParams).block();
+        List<BookResponse> bookResponses = response.getDocuments().stream()
+//                .filter(document -> document.getAuthors().size() > 0) 필요한 컬럼이 없는 데이터를 제외
+                .map(BookResponseMapper::of).collect(Collectors.toList());
+        return new PageImpl<>(bookResponses, Pageable.unpaged(), response.getMeta().getPageable_count());
+    }
+
+    @Transactional
+    public BookResponse searchByISBN(String isbn) {
+        StopWatch timer = new StopWatch();
+        timer.start();
+
+        Optional<Book> bookOptional = bookRepository.findById(isbn);
+        if (bookOptional.isPresent()) return BookResponseMapper.of(bookOptional.get());
+
+        log.info("DB 내 도서 정보 없음");
+        log.info("API 호출");
+
+        // api 요청 리스트 초기화
+        List<Mono<Book>> requests = new ArrayList<>();
+
+        // api 요청 추가
+        requests.add(kakaoBookSearch.searchByISBN(isbn));
+        requests.add(kolisBookSearch.searchByISBN(isbn));
+
+        // api 병렬 요청
+        Book book = requests.stream()
+                .parallel()
+                .map(Mono::block)
+                .reduce(new Book(), Book::merge);
+
+        bookRepository.save(book);
+
+        timer.stop();
+        log.info("총 응답 시간 : {}ms", timer.getTotalTimeMillis());
+        return BookResponseMapper.of(book);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Document.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kakao/dto/Document.java
@@ -24,4 +24,14 @@ public class Document {
     private int price;
     private String thumbnail;
     private String status;
+
+    public String getISBN() {
+        String[] isbnArray = isbn.trim().split(" ");
+        if (isbnArray.length == 0) return "";
+        if (isbnArray.length < 2) return isbnArray[0];
+        for (String s : isbnArray) {
+            if (s.length() == 13) return s;
+        }
+        throw new IllegalArgumentException("잘못된 isbn입니다.");
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/KolisBookSearch.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/KolisBookSearch.java
@@ -1,0 +1,90 @@
+package site.bookmore.bookmore.books.util.api.kolis;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Mono;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.util.api.kolis.dto.Doc;
+import site.bookmore.bookmore.books.util.api.kolis.dto.KolisSearchParams;
+import site.bookmore.bookmore.books.util.api.kolis.dto.KolisSearchResponse;
+import site.bookmore.bookmore.books.util.mapper.BookMapper;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Slf4j
+@Component
+public class KolisBookSearch {
+    private static final String BASE_URL = "https://www.nl.go.kr";
+    private static final String SEARCH_ENDPOINT = "/seoji/SearchApi.do";
+    private final String token;
+
+    private final WebClient webClient = WebClient.create(BASE_URL);
+
+    public KolisBookSearch(@Value("${api.token.kolis}") String kolisToken) {
+        this.token = kolisToken;
+    }
+
+    public Mono<KolisSearchResponse> search(KolisSearchParams kolisSearchParams) {
+        return webClient.get()
+                .uri(uriBuilder -> buildUri(uriBuilder, kolisSearchParams))
+                .retrieve()
+                .bodyToMono(KolisSearchResponse.class);
+    }
+
+    public Mono<Book> searchByISBN(String isbn) {
+        StopWatch stopWatch = new StopWatch();
+        KolisSearchParams kolisSearchParams = KolisSearchParams.builder()
+                .isbn(isbn)
+                .build();
+
+        return webClient.get()
+                .uri(uriBuilder -> buildUri(uriBuilder, kolisSearchParams))
+                .header(AUTHORIZATION, token)
+                .retrieve()
+                .bodyToMono(KolisSearchResponse.class)
+                .map(kolisSearchResponse -> {
+                    List<Doc> docs = kolisSearchResponse.getDocs();
+                    if (docs == null || docs.size() != 1) return new Book();
+                    return BookMapper.of(docs.get(0));
+                })
+                .doOnSubscribe(subscription -> {
+                    log.info("국립중앙도서관 도서 상세조회");
+                    stopWatch.start();
+                })
+                .doOnSuccess((book) -> {
+                    stopWatch.stop();
+                    log.info("국립중앙도서관 도서 상세조회 완료 [{}ms]", stopWatch.getTotalTimeMillis());
+                });
+    }
+
+    private URI buildUri(UriBuilder uriBuilder, KolisSearchParams kolisSearchParams) {
+        uriBuilder.path(SEARCH_ENDPOINT);
+        uriBuilder.queryParam("cert_key", token)
+                .queryParam("result_style", "json");
+
+        Class<?> clazz = kolisSearchParams.getClass();
+        Method[] methods = clazz.getDeclaredMethods();
+
+        try {
+            for (Method method : methods) {
+                String name = method.getName();
+                if (!name.startsWith("get")) continue;
+                String fieldName = name.substring(3).toLowerCase();
+                Object value = method.invoke(kolisSearchParams);
+                if (value != null) uriBuilder.queryParam(fieldName, value);
+            }
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            // InvocationTargetException : KolisSearchParams 필드가 null인경우 api 호출시 제외됨
+        }
+        return uriBuilder.build();
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
@@ -1,0 +1,45 @@
+package site.bookmore.bookmore.books.util.api.kolis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import site.bookmore.bookmore.books.entity.Subject;
+
+@Getter
+public class Doc {
+    @JsonProperty(value = "TITLE")
+    private String title;
+    @JsonProperty(value = "AUTHOR")
+    private String author;
+    @JsonProperty(value = "EA_ISBN")
+    private String isbn;
+    @JsonProperty(value = "EA_ADD_CODE")
+    private String addCode;
+    @JsonProperty(value = "PUBLISHER")
+    private String publisher;
+    @JsonProperty(value = "PRE_PRICE")
+    private String price;
+    @JsonProperty(value = "PAGE")
+    private String page;
+    @JsonProperty(value = "SUBJECT")
+    private String subject;
+    @JsonProperty(value = "EBOOK_YN")
+    private String ebook;
+    @JsonProperty(value = "TITLE_URL")
+    private String image_url;
+    @JsonProperty(value = "BOOK_TB_CNT_URL")
+    private String chapter;
+    @JsonProperty(value = "BOOK_INTRODUCTION_URL")
+    private String introduction;
+    @JsonProperty(value = "BOOK_SUMMARY_URL")
+    private String summary;
+
+    public Subject getSubject() {
+        if (subject != null && !"".equals(subject)) return Subject.of(subject);
+        if (addCode.length() == 5) return Subject.of(addCode.substring(2, 3));
+        return null;
+    }
+
+    public Integer getPage() {
+        return "".equals(page) ? null : Integer.parseInt(page);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/KolisSearchParams.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/KolisSearchParams.java
@@ -1,0 +1,17 @@
+package site.bookmore.bookmore.books.util.api.kolis.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KolisSearchParams {
+    @Builder.Default
+    private int page_no = 1;
+    @Builder.Default
+    private int page_size = 20;
+    private String isbn;
+    private String title;
+    private String author;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/KolisSearchResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/KolisSearchResponse.java
@@ -1,0 +1,15 @@
+package site.bookmore.bookmore.books.util.api.kolis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class KolisSearchResponse {
+    @JsonProperty(value = "PAGE_NO")
+    private String page;
+    @JsonProperty(value = "TOTAL_COUNT")
+    private String totalCount;
+    private List<Doc> docs;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/mapper/BookMapper.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/mapper/BookMapper.java
@@ -1,0 +1,59 @@
+package site.bookmore.bookmore.books.util.mapper;
+
+import site.bookmore.bookmore.books.entity.Author;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.entity.Translator;
+import site.bookmore.bookmore.books.util.api.kakao.dto.Document;
+import site.bookmore.bookmore.books.util.api.kolis.dto.Doc;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class BookMapper {
+    public static Book of(Document document) {
+        Book book = Book.builder()
+                .id(document.getISBN())
+                .title(document.getTitle())
+                .publisher(document.getPublisher())
+                .image(document.getThumbnail())
+                .introduce(document.getContents())
+                .price(document.getPrice())
+                .build();
+
+        Set<Author> authors = document.getAuthors().stream()
+                .map(name -> Author.of(name, book))
+                .collect(Collectors.toSet());
+
+        Set<Translator> translators = document.getTranslators().stream()
+                .map(name -> Translator.of(name, book))
+                .collect(Collectors.toSet());
+
+        book.addAuthors(authors);
+        book.addTranslators(translators);
+
+        return book;
+    }
+
+    public static Book of(Doc doc) {
+        Book book = Book.builder()
+                .id(doc.getIsbn())
+                .title(doc.getTitle())
+                .subject(doc.getSubject())
+                .publisher(doc.getPublisher())
+                .image(doc.getImage_url())
+                .pages(doc.getPage())
+                .price(Integer.parseInt(doc.getPrice().replace(",", "")))
+                .build();
+
+        Set<Author> authors = Arrays.stream(doc.getAuthor()
+                        .replace(" ", "")
+                        .split(","))
+                .map(name -> Author.of(name, book))
+                .collect(Collectors.toSet());
+
+        book.addAuthors(authors);
+
+        return book;
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/mapper/BookResponseMapper.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/mapper/BookResponseMapper.java
@@ -1,0 +1,39 @@
+package site.bookmore.bookmore.books.util.mapper;
+
+import site.bookmore.bookmore.books.dto.BookResponse;
+import site.bookmore.bookmore.books.entity.Author;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.entity.Translator;
+import site.bookmore.bookmore.books.util.api.kakao.dto.Document;
+
+import java.util.stream.Collectors;
+
+public class BookResponseMapper {
+    public static BookResponse of(Document kakaoDocument) {
+        return BookResponse.builder()
+                .isbn(kakaoDocument.getISBN())
+                .title(kakaoDocument.getTitle())
+                .authors(kakaoDocument.getAuthors())
+                .translators(kakaoDocument.getTranslators())
+                .publisher(kakaoDocument.getPublisher())
+                .image(kakaoDocument.getThumbnail())
+                .price(kakaoDocument.getPrice())
+                .build();
+    }
+
+    public static BookResponse of(Book book) {
+        return BookResponse.builder()
+                .isbn(book.getId())
+                .title(book.getTitle())
+                .authors(book.getAuthors().stream().map(Author::getName).collect(Collectors.toList()))
+                .translators(book.getTranslators().stream().map(Translator::getName).collect(Collectors.toList()))
+                .subject(book.getSubject())
+                .publisher(book.getPublisher())
+                .pages(book.getPages())
+                .image(book.getImage())
+                .chapter(book.getChapter())
+                .introduce(book.getIntroduce())
+                .price(book.getPrice())
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요

도서 상세 조회 후 DB 저장 구현.

## 작업 내용

- 상세 조회 시 먼저 DB 조회.
- 검색 결과가 없는 경우 API 호출
- API 호출 결과 DB에 저장.

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [ ] 테스트 코드 작성 및 통과

## 주안점(optional)

- 테스트 코드는  못 짰습니다....
- 픽스쳐 만들기가 너무 어렵네요.
- 빠른 시일내에 짜도록 하겠습니다.

## Merge 전 체크리스트(optional)

- [ ] 국립중앙도서관 api key 환경변수 추가 - 슬랙을 통해 전파하겠습니다.