### PR TITLE
이메일 형식 로직 추가

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/ErrorCode.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
     DUPLICATED_FOLLOW(CONFLICT, "이미 팔로우 중입니다."),
     DUPLICATED_UNFOLLOW(CONFLICT, "이미 언팔로우 중입니다."),
     FOLLOW_NOT_ME(BAD_REQUEST, "나를 팔로우 할 수 없습니다."),
-    DATABASE_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 에러");
+    DATABASE_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 에러"),
+    INVALID_EMAIL_FORMAT(BAD_REQUEST, "올바르지 않는 이메일 형식입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package site.bookmore.bookmore.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import site.bookmore.bookmore.common.dto.ErrorResponse;
@@ -10,6 +11,7 @@ import site.bookmore.bookmore.common.dto.ResultResponse;
 import javax.persistence.PersistenceException;
 
 import static site.bookmore.bookmore.common.exception.ErrorCode.DATABASE_ERROR;
+import static site.bookmore.bookmore.common.exception.ErrorCode.INVALID_EMAIL_FORMAT;
 
 @Slf4j
 @RestControllerAdvice
@@ -26,5 +28,11 @@ public class GlobalExceptionHandler {
         log.error("{} {}", e.getErrorCode().name(), e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(ResultResponse.error(e));
+    }
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResultResponse<ErrorResponse>> handleValidationExceptions(){
+        log.error("{} {}", INVALID_EMAIL_FORMAT.name(), INVALID_EMAIL_FORMAT.getMessage());
+        return ResponseEntity.status(INVALID_EMAIL_FORMAT.getHttpStatus())
+                .body(ResultResponse.error(ErrorResponse.of(INVALID_EMAIL_FORMAT)));
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/bad_request/InvalidEmailFormatException.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/bad_request/InvalidEmailFormatException.java
@@ -1,0 +1,11 @@
+package site.bookmore.bookmore.common.exception.bad_request;
+
+import site.bookmore.bookmore.common.exception.AbstractAppException;
+
+import static site.bookmore.bookmore.common.exception.ErrorCode.INVALID_EMAIL_FORMAT;
+
+public class InvalidEmailFormatException extends AbstractAppException {
+    public InvalidEmailFormatException() {
+        super(INVALID_EMAIL_FORMAT);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
@@ -9,6 +9,8 @@ import site.bookmore.bookmore.common.dto.ResultResponse;
 import site.bookmore.bookmore.users.dto.*;
 import site.bookmore.bookmore.users.service.UserService;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -17,12 +19,12 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/join")
-    public ResultResponse<UserJoinResponse> join(@RequestBody UserJoinRequest userJoinRequest) {
+    public ResultResponse<UserJoinResponse> join(@RequestBody @Valid UserJoinRequest userJoinRequest) {
         return ResultResponse.success(userService.join(userJoinRequest));
     }
 
     @PostMapping("/login")
-    public ResultResponse<UserLoginResponse> login(@RequestBody UserLoginRequest userLoginRequest) {
+    public ResultResponse<UserLoginResponse> login(@RequestBody @Valid UserLoginRequest userLoginRequest) {
         return ResultResponse.success(userService.login(userLoginRequest));
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/UserJoinRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/UserJoinRequest.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.users.entity.User;
 
 
+import javax.validation.constraints.Email;
 import java.time.LocalDate;
 
 @AllArgsConstructor
@@ -13,6 +14,7 @@ import java.time.LocalDate;
 @Getter
 public class UserJoinRequest {
 
+    @Email
     private String email;
     private String password;
     private String nickname;

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/UserLoginRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/UserLoginRequest.java
@@ -4,11 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Email;
+
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class UserLoginRequest {
+    @Email
     private String email;
     private String password;
 }


### PR DESCRIPTION
## 개요
 이메일 형식이 아닐 시 회원가입이 불가능 하게 구현

## 작업 내용

-  join, login requset 에 email 어노테이션 추가
-  GlobalHandler 에 예외 처리 추가 

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과
