### PR TITLE
회원 상세 조회 기능 구현

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
@@ -41,4 +41,11 @@ public class ReviewController {
         boolean result = reviewService.doLikes(email, id);
         return ResultResponse.success(result ? "좋아요를 눌렀습니다." : "좋아요가 취소되었습니다.");
     }
+
+    // 유저로 도서 리뷰 조회
+    @GetMapping("/reviews/{id}")
+    public ResultResponse<Page<ReviewPageResponse>> readByUser(@PageableDefault(size = 5, sort = "createdDatetime", direction = Sort.Direction.DESC) Pageable pageable, @PathVariable Long id) {
+        Page<ReviewPageResponse> reviewPage = reviewService.readByUser(pageable, id);
+        return ResultResponse.success(reviewPage);
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
@@ -11,7 +11,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findByBook(Pageable pageable, Book book);
 
-    Long countByAuthor(User user);
+    Long countByAuthorAndDeletedDatetimeIsNull(User user);
 
-    Page<Review> findByAuthor(Pageable pageable, User user);
+    Page<Review> findByAuthorAndDeletedDatetimeIsNull(Pageable pageable, User user);
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.bookmore.bookmore.books.entity.Book;
 import site.bookmore.bookmore.books.entity.Review;
+import site.bookmore.bookmore.users.entity.User;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findByBook(Pageable pageable, Book book);
+
+    Long countByAuthor(User user);
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/repository/ReviewRepository.java
@@ -12,4 +12,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findByBook(Pageable pageable, Book book);
 
     Long countByAuthor(User user);
+
+    Page<Review> findByAuthor(Pageable pageable, User user);
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -89,4 +89,13 @@ public class ReviewService {
 
         return result;
     }
+
+    // 유저로 도서 리뷰 조회
+    @Transactional
+    public Page<ReviewPageResponse> readByUser(Pageable pageable, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        return reviewRepository.findByAuthor(pageable, user).map(ReviewPageResponse::of);
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -96,6 +96,6 @@ public class ReviewService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
-        return reviewRepository.findByAuthor(pageable, user).map(ReviewPageResponse::of);
+        return reviewRepository.findByAuthorAndDeletedDatetimeIsNull(pageable, user).map(ReviewPageResponse::of);
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/controller/FollowController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/controller/FollowController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import site.bookmore.bookmore.common.dto.ResultResponse;
 import site.bookmore.bookmore.users.dto.FollowerResponse;
 import site.bookmore.bookmore.users.dto.FollowingResponse;
+import site.bookmore.bookmore.users.dto.UserDetailResponse;
 import site.bookmore.bookmore.users.service.FollowService;
 
 @RestController
@@ -37,5 +38,12 @@ public class FollowController {
     @GetMapping("/{id}/follower")
     public ResultResponse<Page<FollowerResponse>> findAllFollower(@PathVariable Long id, Pageable pageable) {
         return ResultResponse.success(followService.findAllFollower(id, pageable));
+    }
+
+    // 유저 아이디로 팔로워 수, 팔로잉 수, 리뷰 수 조회
+    @GetMapping("/{id}")
+    public ResultResponse<UserDetailResponse> getDetail(@PathVariable Long id) {
+        UserDetailResponse response = followService.getDetail(id);
+        return ResultResponse.success(response);
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
@@ -36,4 +36,11 @@ public class UserController {
         String email = authentication.getName();
         return ResultResponse.success(userService.delete(email, id));
     }
+
+    // 유저 아이디로 팔로워 수, 팔로잉 수, 리뷰 수 조회
+    @GetMapping("/{id}")
+    public ResultResponse<UserDetailResponse> getDetail(@PathVariable Long id) {
+        UserDetailResponse response = userService.getDetail(id);
+        return ResultResponse.success(response);
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
@@ -36,11 +36,4 @@ public class UserController {
         String email = authentication.getName();
         return ResultResponse.success(userService.delete(email, id));
     }
-
-    // 유저 아이디로 팔로워 수, 팔로잉 수, 리뷰 수 조회
-    @GetMapping("/{id}")
-    public ResultResponse<UserDetailResponse> getDetail(@PathVariable Long id) {
-        UserDetailResponse response = userService.getDetail(id);
-        return ResultResponse.success(response);
-    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/UserDetailResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/UserDetailResponse.java
@@ -1,0 +1,16 @@
+package site.bookmore.bookmore.users.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class UserDetailResponse {
+    private Long followers;
+    private Long followings;
+    private Long reviews;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
@@ -19,4 +19,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Page<Follow> findByFollowingAndDeletedDatetimeIsNull(Pageable pageable, User following);
 
     List<Follow> findAllByFollowingAndDeletedDatetimeIsNull(User following);
+
+    Long countByFollower(User user);
+
+    Long countByFollowing(User user);
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/repositroy/FollowRepository.java
@@ -20,7 +20,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     List<Follow> findAllByFollowingAndDeletedDatetimeIsNull(User following);
 
-    Long countByFollower(User user);
+    Long countByFollowerAndDeletedDatetimeIsNull(User user);
 
-    Long countByFollowing(User user);
+    Long countByFollowingAndDeletedDatetimeIsNull(User user);
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateEmailException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateNicknameException;
 import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
@@ -16,6 +17,7 @@ import site.bookmore.bookmore.security.provider.JwtProvider;
 import site.bookmore.bookmore.users.dto.*;
 import site.bookmore.bookmore.users.entity.Role;
 import site.bookmore.bookmore.users.entity.User;
+import site.bookmore.bookmore.users.repositroy.FollowRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
 
 
@@ -25,6 +27,8 @@ public class UserService implements UserDetailsService {
 
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final FollowRepository followRepository;
+    private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
 
     @Override
@@ -107,4 +111,19 @@ public class UserService implements UserDetailsService {
         return UserResponse.of(user, "회원 탈퇴 완료.");
     }
 
+    // 유저 아이디로 팔로워 수, 팔로잉 수, 리뷰 수 조회
+    public UserDetailResponse getDetail(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Long followers = followRepository.countByFollower(user);
+        Long followings = followRepository.countByFollowing(user);
+        Long reviews = reviewRepository.countByAuthor(user);
+
+        return UserDetailResponse.builder()
+                .followers(followers)
+                .followings(followings)
+                .reviews(reviews)
+                .build();
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
@@ -7,7 +7,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateEmailException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateNicknameException;
 import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
@@ -17,7 +16,6 @@ import site.bookmore.bookmore.security.provider.JwtProvider;
 import site.bookmore.bookmore.users.dto.*;
 import site.bookmore.bookmore.users.entity.Role;
 import site.bookmore.bookmore.users.entity.User;
-import site.bookmore.bookmore.users.repositroy.FollowRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
 
 
@@ -27,8 +25,7 @@ public class UserService implements UserDetailsService {
 
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
-    private final FollowRepository followRepository;
-    private final ReviewRepository reviewRepository;
+
     private final UserRepository userRepository;
 
     @Override
@@ -109,21 +106,5 @@ public class UserService implements UserDetailsService {
         userFindId.delete();
 
         return UserResponse.of(user, "회원 탈퇴 완료.");
-    }
-
-    // 유저 아이디로 팔로워 수, 팔로잉 수, 리뷰 수 조회
-    public UserDetailResponse getDetail(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        Long followers = followRepository.countByFollower(user);
-        Long followings = followRepository.countByFollowing(user);
-        Long reviews = reviewRepository.countByAuthor(user);
-
-        return UserDetailResponse.builder()
-                .followers(followers)
-                .followings(followings)
-                .reviews(reviews)
-                .build();
     }
 }

--- a/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/controller/ReviewControllerTest.java
@@ -79,6 +79,24 @@ class ReviewControllerTest {
         verify(reviewService).read(any(), eq("9791158393083"));
     }
 
+    @Test
+    @DisplayName("유저로 도서 리뷰 조회 성공")
+    @WithMockUser
+    void readByUser_success() throws Exception {
+        // when
+        when(reviewService.readByUser(any(), eq(1L)))
+                .thenReturn(Page.empty());
+
+        // then
+        mockMvc.perform(get("/api/v1/books/reviews/1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("SUCCESS"))
+                .andExpect(jsonPath("$.result").exists());
+
+        verify(reviewService).readByUser(any(), eq(1L));
+    }
+
     /* ========== 도서 리뷰 좋아요 | 취소 ========== */
     @Test
     @DisplayName("도서 리뷰 좋아요 성공")

--- a/backend/src/test/java/site/bookmore/bookmore/users/service/FollowServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/users/service/FollowServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationEventPublisher;
+import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.ErrorCode;
 import site.bookmore.bookmore.common.exception.bad_request.FollowNotMeException;
 import site.bookmore.bookmore.common.exception.not_found.FollowNotFoundException;
@@ -25,12 +26,13 @@ class FollowServiceTest {
 
     FollowService followService;
     FollowRepository followRepository = mock(FollowRepository.class);
+    ReviewRepository reviewRepository = mock(ReviewRepository.class);
     UserRepository userRepository = mock(UserRepository.class);
     private final ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
 
     @BeforeEach
     void setUp() {
-        followService = new FollowService(followRepository, userRepository, publisher);
+        followService = new FollowService(followRepository, reviewRepository, userRepository, publisher);
     }
 
     @Test

--- a/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.AbstractAppException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateEmailException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateNicknameException;
@@ -16,7 +15,6 @@ import site.bookmore.bookmore.users.dto.UserJoinRequest;
 import site.bookmore.bookmore.users.dto.UserLoginRequest;
 import site.bookmore.bookmore.users.dto.UserUpdateRequest;
 import site.bookmore.bookmore.users.entity.User;
-import site.bookmore.bookmore.users.repositroy.FollowRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
 
 import java.time.LocalDate;
@@ -32,15 +30,13 @@ import static site.bookmore.bookmore.common.exception.ErrorCode.*;
 
 class UserServiceTest {
 
-    private final FollowRepository followRepository = mock(FollowRepository.class);
-    private final ReviewRepository reviewRepository = mock(ReviewRepository.class);
     private final UserRepository userRepository = mock(UserRepository.class);
 
     private final JwtProvider jwtProvider = mock(JwtProvider.class);
 
     private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
 
-    private final UserService userService = new UserService(passwordEncoder, jwtProvider, followRepository, reviewRepository, userRepository);
+    private final UserService userService = new UserService(passwordEncoder, jwtProvider, userRepository);
 
     private final User user = User.builder()
             .id(0L)

--- a/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import site.bookmore.bookmore.books.repository.ReviewRepository;
 import site.bookmore.bookmore.common.exception.AbstractAppException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateEmailException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateNicknameException;
@@ -15,6 +16,7 @@ import site.bookmore.bookmore.users.dto.UserJoinRequest;
 import site.bookmore.bookmore.users.dto.UserLoginRequest;
 import site.bookmore.bookmore.users.dto.UserUpdateRequest;
 import site.bookmore.bookmore.users.entity.User;
+import site.bookmore.bookmore.users.repositroy.FollowRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
 
 import java.time.LocalDate;
@@ -30,13 +32,15 @@ import static site.bookmore.bookmore.common.exception.ErrorCode.*;
 
 class UserServiceTest {
 
+    private final FollowRepository followRepository = mock(FollowRepository.class);
+    private final ReviewRepository reviewRepository = mock(ReviewRepository.class);
     private final UserRepository userRepository = mock(UserRepository.class);
 
     private final JwtProvider jwtProvider = mock(JwtProvider.class);
 
     private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
 
-    private final UserService userService = new UserService(passwordEncoder, jwtProvider, userRepository);
+    private final UserService userService = new UserService(passwordEncoder, jwtProvider, followRepository, reviewRepository, userRepository);
 
     private final User user = User.builder()
             .id(0L)


### PR DESCRIPTION
## 개요

1. 프론트엔드에서의 Detail 페이지에 들어갈 팔로워 수, 팔로잉 수, 리뷰 수를 리턴하는 기능 구현
2. 유저 아이디로 조회 시 작성한 모든 리뷰가 페이지로 리턴되는 기능 구현

## 작업 내용

- 프론트엔드: Detail 페이지에는 총 3가지의 탭이 있습니다.
- 1. 팔로워 수와 팔로워 리스트
- 2. 팔로잉 수와 팔로잉 리스트
- 3. 리뷰 수와 작성한 모든 리뷰 리스트

1번과 2번의 리스트 리턴 기능은 이미 구현되어 있기에 3번의 리뷰 리스트 리턴 기능만 구현했습니다. 

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [ ] 테스트 코드 작성 및 통과

## 주안점
- 팔로워 수,  팔로잉 수, 리뷰수를 리턴하는 기능은 아직 테스트 코드를 작성하지 않았습니다. 
- Detail 페이지는 프론트엔드를 어떻게 구현하느냐가 더욱 중요할 것 같습니다.