### PR TITLE
도서 검색 기능 리팩토링

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/controller/BookController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/controller/BookController.java
@@ -20,7 +20,7 @@ public class BookController {
     @GetMapping("")
     public ResultResponse<Page<BookResponse>> search(KakaoSearchParams kakaoSearchParams) {
         // 카카오 도서 검색 요청
-        return ResultResponse.success(bookService.searchAtKakao(kakaoSearchParams));
+        return ResultResponse.success(bookService.search(kakaoSearchParams));
     }
 
     @GetMapping("/{isbn}")

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/BookService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/BookService.java
@@ -3,8 +3,6 @@ package site.bookmore.bookmore.books.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StopWatch;
@@ -16,14 +14,12 @@ import site.bookmore.bookmore.books.entity.Book;
 import site.bookmore.bookmore.books.repository.BookRepository;
 import site.bookmore.bookmore.books.util.api.kakao.KakaoBookSearch;
 import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
-import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchResponse;
 import site.bookmore.bookmore.books.util.api.kolis.KolisBookSearch;
 import site.bookmore.bookmore.books.util.mapper.BookResponseMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -33,13 +29,10 @@ public class BookService {
     private final KakaoBookSearch kakaoBookSearch;
     private final KolisBookSearch kolisBookSearch;
 
-    public Page<BookResponse> searchAtKakao(KakaoSearchParams kakaoSearchParams) {
+    public Page<BookResponse> search(KakaoSearchParams kakaoSearchParams) {
         // Todo. 카카오 api 의존도 해결
-        KakaoSearchResponse response = kakaoBookSearch.search(kakaoSearchParams).block();
-        List<BookResponse> bookResponses = response.getDocuments().stream()
-//                .filter(document -> document.getAuthors().size() > 0) 필요한 컬럼이 없는 데이터를 제외
-                .map(BookResponseMapper::of).collect(Collectors.toList());
-        return new PageImpl<>(bookResponses, Pageable.unpaged(), response.getMeta().getPageable_count());
+        Page<Book> response = kakaoBookSearch.search(kakaoSearchParams).block();
+        return response.map(BookResponseMapper::of);
     }
 
     @Transactional
@@ -52,7 +45,7 @@ public class BookService {
             timer.stop();
             log.info("총 응답 시간 : {}ms", timer.getTotalTimeMillis());
             return BookResponseMapper.of(bookOptional.get());
-        };
+        }
 
         log.info("DB 내 도서 정보 없음");
         log.info("API 호출");

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/BookSearch.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/BookSearch.java
@@ -1,0 +1,11 @@
+package site.bookmore.bookmore.books.util.api;
+
+import org.springframework.data.domain.Page;
+import reactor.core.publisher.Mono;
+import site.bookmore.bookmore.books.entity.Book;
+
+public interface BookSearch<T> {
+    Mono<Page<Book>> search(T searchParams);
+
+    Mono<Book> searchByISBN(String isbn);
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
@@ -40,6 +40,7 @@ public class Doc {
     }
 
     public Integer getPage() {
+        page = page.replaceAll("[\\sa-zA-Z.]", "");
         return "".equals(page) ? null : Integer.parseInt(page);
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
@@ -49,4 +49,8 @@ public class Doc {
         page = page.replaceAll("[\\sa-zA-Z.]", "");
         return "".equals(page) ? null : Integer.parseInt(page);
     }
+
+    public Integer getPrice() {
+        return Integer.parseInt(price.replace(",", ""));
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
@@ -1,10 +1,16 @@
 package site.bookmore.bookmore.books.util.api.kolis.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.books.entity.Subject;
 
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Doc {
     @JsonProperty(value = "TITLE")
     private String title;

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/Doc.java
@@ -46,7 +46,7 @@ public class Doc {
     }
 
     public Integer getPage() {
-        page = page.replaceAll("[\\sa-zA-Z.]", "");
+        page = page.replaceAll("[\\sa-zA-Z.,]", "");
         return "".equals(page) ? null : Integer.parseInt(page);
     }
 

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/KolisSearchResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/api/kolis/dto/KolisSearchResponse.java
@@ -12,4 +12,8 @@ public class KolisSearchResponse {
     @JsonProperty(value = "TOTAL_COUNT")
     private String totalCount;
     private List<Doc> docs;
+
+    public long getTotalCount() {
+        return Long.parseLong(totalCount);
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/util/mapper/BookMapper.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/util/mapper/BookMapper.java
@@ -43,7 +43,7 @@ public class BookMapper {
                 .publisher(doc.getPublisher())
                 .image(doc.getImage_url())
                 .pages(doc.getPage())
-                .price(Integer.parseInt(doc.getPrice().replace(",", "")))
+                .price(doc.getPrice())
                 .build();
 
         Set<Author> authors = Arrays.stream(doc.getAuthor()

--- a/backend/src/test/java/site/bookmore/bookmore/books/controller/BookControllerTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/controller/BookControllerTest.java
@@ -9,15 +9,12 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import reactor.core.publisher.Mono;
 import site.bookmore.bookmore.books.dto.BookResponse;
 import site.bookmore.bookmore.books.service.BookService;
-import site.bookmore.bookmore.books.util.api.kakao.KakaoBookSearch;
 import site.bookmore.bookmore.books.util.api.kakao.dto.Document;
 import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
 import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchResponse;
 import site.bookmore.bookmore.books.util.api.kakao.dto.Meta;
-import site.bookmore.bookmore.books.util.api.kolis.KolisBookSearch;
 import site.bookmore.bookmore.books.util.mapper.BookResponseMapper;
 
 import java.util.ArrayList;
@@ -71,7 +68,7 @@ class BookControllerTest {
         KakaoSearchResponse kakaoSearchResponse = new KakaoSearchResponse(meta, documents);
         List<BookResponse> bookResponses = kakaoSearchResponse.getDocuments().stream().map(BookResponseMapper::of).collect(Collectors.toList());
 
-        given(bookService.searchAtKakao(any(KakaoSearchParams.class))).willReturn(new PageImpl<>(bookResponses, Pageable.unpaged(),kakaoSearchResponse.getMeta().getPageable_count()));
+        given(bookService.search(any(KakaoSearchParams.class))).willReturn(new PageImpl<>(bookResponses, Pageable.unpaged(),kakaoSearchResponse.getMeta().getPageable_count()));
 
         mockMvc.perform(get("/api/v1/books?query=정의란 무엇인가")
                         .with(csrf()))
@@ -80,7 +77,7 @@ class BookControllerTest {
                 .andExpect(jsonPath("$.result.content").isArray())
                 .andExpect(jsonPath("$.result.totalElements").value(meta.getPageable_count()));
 
-        verify(bookService).searchAtKakao(any(KakaoSearchParams.class));
+        verify(bookService).search(any(KakaoSearchParams.class));
     }
 
     @Test
@@ -99,7 +96,7 @@ class BookControllerTest {
 
         List<BookResponse> bookResponses = kakaoSearchResponse.getDocuments().stream().map(BookResponseMapper::of).collect(Collectors.toList());
 
-        given(bookService.searchAtKakao(any(KakaoSearchParams.class))).willReturn(new PageImpl<>(bookResponses));
+        given(bookService.search(any(KakaoSearchParams.class))).willReturn(new PageImpl<>(bookResponses));
 
         mockMvc.perform(get("/api/v1/books?query=책이름")
                         .with(csrf()))
@@ -109,6 +106,6 @@ class BookControllerTest {
                 .andExpect(jsonPath("$.result.content").isArray())
                 .andExpect(jsonPath("$.result.totalElements").value(meta.getPageable_count()));
 
-        verify(bookService).searchAtKakao(any(KakaoSearchParams.class));
+        verify(bookService).search(any(KakaoSearchParams.class));
     }
 }

--- a/backend/src/test/java/site/bookmore/bookmore/books/service/BookServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/service/BookServiceTest.java
@@ -1,0 +1,115 @@
+package site.bookmore.bookmore.books.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import reactor.core.publisher.Mono;
+import site.bookmore.bookmore.books.dto.BookResponse;
+import site.bookmore.bookmore.books.entity.Book;
+import site.bookmore.bookmore.books.repository.BookRepository;
+import site.bookmore.bookmore.books.util.api.kakao.KakaoBookSearch;
+import site.bookmore.bookmore.books.util.api.kakao.dto.KakaoSearchParams;
+import site.bookmore.bookmore.books.util.api.kolis.KolisBookSearch;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class BookServiceTest {
+    private final BookRepository bookRepository = Mockito.mock(BookRepository.class);
+    private final KakaoBookSearch kakaoBookSearch = Mockito.mock(KakaoBookSearch.class);
+    private final KolisBookSearch kolisBookSearch = Mockito.mock(KolisBookSearch.class);
+    private final BookService bookService = new BookService(bookRepository, kakaoBookSearch, kolisBookSearch);
+
+    @Test
+    void search() {
+        List<Book> books = Stream.of(1, 2, 3, 4, 5)
+                .map(i ->
+                        Book.builder()
+                            .id("1000" + i)
+                            .publisher("publisher" + i)
+                            .title("title" + i)
+                            .price(10000)
+                            .build()
+                ).collect(Collectors.toList());
+
+        Page<Book> bookPage = new PageImpl<>(books);
+        given(kakaoBookSearch.search(any(KakaoSearchParams.class))).willReturn(Mono.just(bookPage));
+
+        KakaoSearchParams kakaoSearchParams = KakaoSearchParams.builder()
+                .size(5)
+                .page(1)
+                .query("title")
+                .build();
+
+        Page<BookResponse> result = bookService.search(kakaoSearchParams);
+
+        assertEquals(books.size(), result.getContent().size());
+        verify(kakaoBookSearch).search(any(KakaoSearchParams.class));
+    }
+
+    @Test
+    void searchByISBN_from_db() {
+        Book book = Book.builder()
+                .id("10001")
+                .title("title1")
+                .publisher("publisher1")
+                .price(10000)
+                .build();
+        given(bookRepository.findById("10001")).willReturn(Optional.of(book));
+
+        BookResponse result = bookService.searchByISBN("10001");
+
+        assertEquals(book.getId(), result.getIsbn());
+        assertEquals(book.getTitle(), result.getTitle());
+        assertEquals(book.getPublisher(), result.getPublisher());
+        assertEquals(book.getPrice(), result.getPrice());
+
+        verify(bookRepository).findById("10001");
+        verify(kakaoBookSearch, never()).searchByISBN(anyString());
+        verify(kolisBookSearch, never()).searchByISBN(anyString());
+    }
+
+    @Test
+    void searchByISBN_from_api() {
+        Book book1 = Book.builder()
+                .id("10001")
+                .title("title1")
+                .publisher("publisher1")
+                .price(10000)
+                .build();
+
+        Book book2 = Book.builder()
+                .id("10001")
+                .title("title1")
+                .pages(100)
+                .image("http://test.image.com/img.jpg")
+                .build();
+
+        given(bookRepository.findById("10001")).willReturn(Optional.empty());
+        given(kakaoBookSearch.searchByISBN("10001")).willReturn(Mono.just(book1));
+        given(kolisBookSearch.searchByISBN("10001")).willReturn(Mono.just(book2));
+
+        BookResponse result = bookService.searchByISBN("10001");
+
+        assertEquals(book1.getId(), result.getIsbn());
+        assertEquals(book1.getTitle(), result.getTitle());
+        assertEquals(book1.getPublisher(), result.getPublisher());
+        assertEquals(book1.getPrice(), result.getPrice());
+        assertEquals(book2.getPages(), result.getPages());
+        assertEquals(book2.getImage(), result.getImage());
+
+        verify(bookRepository).findById("10001");
+        verify(kakaoBookSearch).searchByISBN(anyString());
+        verify(kolisBookSearch).searchByISBN(anyString());
+    }
+}

--- a/backend/src/test/java/site/bookmore/bookmore/books/util/api/kolis/dto/DocTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/util/api/kolis/dto/DocTest.java
@@ -1,0 +1,64 @@
+package site.bookmore.bookmore.books.util.api.kolis.dto;
+
+import org.junit.jupiter.api.Test;
+import site.bookmore.bookmore.books.entity.Subject;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocTest {
+
+    @Test
+    void getSubject() {
+        String SUBJECT_CODE = "3";
+        Subject EXPECTED = Subject.사회과학;
+        Doc doc = Doc.builder()
+                .subject(SUBJECT_CODE)
+                .build();
+
+        assertEquals(EXPECTED, doc.getSubject());
+    }
+
+    @Test
+    void getSubject_from_addCode() {
+        String ADD_CODE = "00300";
+        Subject EXPECTED = Subject.사회과학;
+        Doc doc = Doc.builder()
+                .subject(null)
+                .addCode(ADD_CODE)
+                .build();
+
+        assertEquals(EXPECTED, doc.getSubject());
+    }
+
+    @Test
+    void getSubject_is_null() {
+        Doc doc = Doc.builder()
+                .subject("")
+                .addCode("")
+                .build();
+
+        assertNull(doc.getSubject());
+    }
+
+    @Test
+    void getPage() {
+        String PAGE = "123";
+        int EXPECTED = 123;
+        Doc doc = Doc.builder()
+                .page(PAGE)
+                .build();
+
+        assertEquals(EXPECTED, doc.getPage());
+    }
+
+    @Test
+    void getPage_replace() {
+        String PAGE = "123 p.";
+        int EXPECTED = 123;
+        Doc doc = Doc.builder()
+                .page(PAGE)
+                .build();
+
+        assertEquals(EXPECTED, doc.getPage());
+    }
+}


### PR DESCRIPTION
## 개요

도서 검색 기능 리팩토링

## 작업 내용

- 국립 중앙 도서관 응답 데이터 파싱 수정
  - 페이지 형식 정수로 가공 ["367 p.", "xviii, 434 p."] 
- BookSearch interface 구현
- 테스트 코드 작성

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과