### PR TITLE
Jacoco 설정 및 github actions workflow 수정

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -46,7 +46,7 @@ jobs:
         id: jacoco
         uses: madrapps/jacoco-report@v1.3
         with:
-          paths: ${{ github.workspace }}/backend//build/reports/jacoco/test/jacocoTestReport.xml
+          paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,51 @@
+# Repository의 Actions 탭에 나타날 Workflow 이름으로 필수 옵션은 아님
+name: Jacoco Test
+
+# Workflow를 실행시키기 위한 Event 목록
+on:
+  # 하단 코드에 따라 develop 브랜치에 Push 또는 Pull Request 이벤트가 발생한 경우에 Workflow가 실행
+  # 만약 브랜치 구분 없이 이벤트를 지정하고 싶을 경우에는 단순히 아래와 같이 작성도 가능함
+  # on: [push, pull_request] 
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - 'backend/**'
+
+# 해당 옵션을 통해 사용자가 직접 Actions 탭에서 Workflow를 실행시킬 수 있음
+  workflow_dispatch:
+  
+    
+# 해당 Workflow의 하나 이상의 Job 목록
+jobs:
+  jacoco-test:
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Test with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: test
+          build-root-directory: backend/
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.3
+        with:
+          paths: ${{ github.workspace }}/backend//build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 40
+          min-coverage-changed-files: 60
+          title: Code Coverage
+          update-comment: true

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -19,6 +19,9 @@ on:
 # 해당 Workflow의 하나 이상의 Job 목록
 jobs:
   jacoco-test:
+
+    runs-on: ubuntu-latest
+
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,15 @@ jobs:
         arguments: build
         build-root-directory: backend/
 
+    - name: Add coverage to PR
+      id: jacoco
+      uses: madrapps/jacoco-report@v1.3
+      with:
+        paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
+        min-coverage-overall: 40
+        min-coverage-changed-files: 60
+
     - name: Upload Gradle Build Artifact
       uses: actions/upload-artifact@v3.1.2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       id: jacoco
       uses: madrapps/jacoco-report@v1.3
       with:
-        paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+        paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         min-coverage-overall: 40
         min-coverage-changed-files: 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         min-coverage-overall: 40
         min-coverage-changed-files: 60
+        title: Code Coverage
+        update-comment: true
 
     - name: Upload Gradle Build Artifact
       uses: actions/upload-artifact@v3.1.2

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.5'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'jacoco'
 }
 
 group = 'site.bookmore'
@@ -37,6 +38,32 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        html.enabled true
+        xml.enabled true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(
+                    dir: it,
+                    includes: [
+                        'site/bookmore/bookmore/**/controller/*',
+                        'site/bookmore/bookmore/**/service/*',
+                    ],
+                    excludes: [
+                        'site/bookmore/bookmore/common/*'
+            ])
+        }))
+    }
+}
+
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## 개요

Jacoco 설정

## 작업 내용

- Jacoco 설정
- 컨트롤러 레이어와 서비스 레이어만 커버리지 측정하도록 해두었습니다.
- Github actions로 PR에 커버리지 측정 결과를 표시하도록 추가했습니다.
- main workflow에 결과 코멘트 작성
- develop 브랜치에서 test 진행 후 결과 보고하도록 workflow 추가

## Merge 전 체크리스트

- @yjyj1023 workflow 리뷰 잘 부탁드립니다! 참고 : [jacoco-report](https://github.com/marketplace/actions/jacoco-report)