### PR TITLE
팔로잉/팔로워/리뷰 카운트 기능 추가

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -40,6 +40,7 @@ public class ReviewService {
     private final UserRepository userRepository;
     private final ApplicationEventPublisher publisher;
 
+    @Transactional
     // 도서 리뷰 등록
     public Long create(ReviewRequest reviewRequest, String isbn, String email) {
         User user = userRepository.findByEmail(email)
@@ -50,6 +51,8 @@ public class ReviewService {
 
         Review review = reviewRequest.toEntity(user, book);
         Review savedReview = reviewRepository.save(review);
+
+        user.plusReviewCount(user.getReviewCount());
 
         // 나의 팔로잉이 리뷰를 등록했을 때의 알림 발생
         List<Follow> followers = followRepository.findAllByFollowingAndDeletedDatetimeIsNull(user);

--- a/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/service/ReviewService.java
@@ -104,6 +104,7 @@ public class ReviewService {
         }
 
         review.delete();
+        user.minusReviewCount(user.getReviewCount());
 
         return review.getId();
     }

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowerResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowerResponse.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.users.entity.Follow;
+import site.bookmore.bookmore.users.entity.Tier;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 @Builder
@@ -15,20 +15,22 @@ import java.time.format.DateTimeFormatter;
 @NoArgsConstructor
 public class FollowerResponse {
     private Long id;
-    private Long follower;
-    private String email;
+    private Long followerId;
     private String nickname;
-    private LocalDate birth;
+    private Integer followerCount;
+    private Integer followingCount;
+    private Integer reviewsCount;
+    private Tier tier;
     private String createdDatetime;
-    private String lastModifiedDatetime;
 
     public FollowerResponse(Follow follow) {
         this.id = follow.getId();
-        this.follower = follow.getFollower().getId();
-        this.email = follow.getFollower().getEmail();
+        this.followerId = follow.getFollower().getId();
         this.nickname = follow.getFollower().getNickname();
-        this.birth = follow.getFollower().getBirth();
+        this.followerCount = follow.getFollower().getFollowerCount();
+        this.followingCount = follow.getFollower().getFollowingCount();
+        this.reviewsCount = follow.getFollower().getReviewCount();
+        this.tier = follow.getFollower().getTier();
         this.createdDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getCreatedDatetime());
-        this.lastModifiedDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getLastModifiedDatetime());
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowingResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowingResponse.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.users.entity.Follow;
+import site.bookmore.bookmore.users.entity.Tier;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 @Builder
@@ -15,20 +15,22 @@ import java.time.format.DateTimeFormatter;
 @NoArgsConstructor
 public class FollowingResponse {
     private Long id;
-    private Long following;
-    private String email;
+    private Long followingId;
     private String nickname;
-    private LocalDate birth;
+    private Integer followerCount;
+    private Integer followingCount;
+    private Integer reviewsCount;
+    private Tier tier;
     private String createdDatetime;
-    private String lastModifiedDatetime;
 
     public FollowingResponse(Follow follow) {
         this.id = follow.getId();
-        this.following = follow.getFollowing().getId();
-        this.email = follow.getFollowing().getEmail();
+        this.followingId = follow.getFollowing().getId();
         this.nickname = follow.getFollowing().getNickname();
-        this.birth = follow.getFollowing().getBirth();
+        this.followerCount = follow.getFollowing().getFollowerCount();
+        this.followingCount = follow.getFollowing().getFollowingCount();
+        this.reviewsCount = follow.getFollowing().getReviewCount();
+        this.tier = follow.getFollowing().getTier();
         this.createdDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getCreatedDatetime());
-        this.lastModifiedDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getLastModifiedDatetime());
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
@@ -49,14 +49,26 @@ public class User extends BaseEntity implements UserDetails {
     @Column(nullable = false)
     private boolean enabled = true;
 
+    @Column
+    private int followerCount = 0;
+
+    @Column
+    private int followingCount = 0;
+
+    @Column
+    private int reviewCount = 0;
+
     @Builder
-    public User(Long id, String email, String password, Role role, String nickname, Tier tier, LocalDate birth) {
+    public User(Long id, String email, String password, Role role, String nickname, Tier tier, LocalDate birth, int followerCount, int followingCount, int reviewCount) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.tier = tier;
         this.birth = birth;
+        this.followerCount = followerCount;
+        this.followingCount = followingCount;
+        this.reviewCount = reviewCount;
         this.role = role == null ? Role.ROLE_USER : role;
     }
 
@@ -82,6 +94,30 @@ public class User extends BaseEntity implements UserDetails {
         if (birth != null) {
             this.birth = birth;
         }
+    }
+
+    public void plusFollowerCount(int followerCount) {
+        this.followerCount = followerCount + 1;
+    }
+
+    public void minusFollowerCount(int followerCount) {
+        this.followerCount = followerCount - 1;
+    }
+
+    public void plusFollowingCount(int followingCount) {
+        this.followingCount = followingCount + 1;
+    }
+
+    public void minusFollowingCount(int followingCount) {
+        this.followingCount = followingCount - 1;
+    }
+
+    public void plusReviewCount(int reviewCount) {
+        this.reviewCount = reviewCount + 1;
+    }
+
+    public void minusReviewCount(int reviewCount) {
+        this.reviewCount = reviewCount - 1;
     }
 
 


### PR DESCRIPTION
## 개요

- 팔로잉/팔로워/리뷰 카운트 기능 추가

## 작업 내용

- User 테이블에 FollowingCount/FollowerCount/ReviewCount 컬럼 추가 및 +1, -1 메소드 추가
- Following/Follower 조회 시 각 User의 Id, nickname, 팔로워 수, 팔로잉 수, 리뷰수, tier, createdDatetime 가 출력 되도록 수정

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과

## 주안점(optional)

-  follow 테이블을 조회 할 때마다 카운트를 하면 성능이 떨어질 것 같아서 팔로우, 언팔로우, 리뷰 등록, 리뷰 삭제 시 +- 카운트 하도록 했습니다. 괜찮은지 의견 부탁 드립니다!