### PR TITLE
[Hotfix] 도서 상세조회 번역가가 없는 경우 DB에러 이슈 해결

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/repository/BookRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/repository/BookRepository.java
@@ -1,13 +1,10 @@
 package site.bookmore.bookmore.books.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import site.bookmore.bookmore.books.entity.Book;
 
 import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, String> {
-    @Query("SELECT b FROM Book b JOIN FETCH b.authors JOIN FETCH  b.translators WHERE b.id=:isbn")
-    Optional<Book> findById(@Param("isbn") String isbn);
+    Optional<Book> findById(String isbn);
 }


### PR DESCRIPTION
## 개요

도서 상세조회 시 번역가가 없는 경우 DB 에러가 발생하는 이슈를 수정하였습니다.

## 작업 내용

- fetch join으로 저자와 번역가를 함께 불러오는데 번역가가 없는 경우 아무런 데이터가 조회되지 않습니다.
- 직접 작성한 jpql을 지워 해결해두었습니다.

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
