### PR TITLE
팔로잉/팔로워 카운트 기능 추가

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowerResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowerResponse.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.users.entity.Follow;
+import site.bookmore.bookmore.users.entity.Tier;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 @Builder
@@ -15,20 +15,20 @@ import java.time.format.DateTimeFormatter;
 @NoArgsConstructor
 public class FollowerResponse {
     private Long id;
-    private Long follower;
-    private String email;
+    private Long followerId;
     private String nickname;
-    private LocalDate birth;
+    private Integer followerCount;
+    private Integer followingCount;
+    private Tier tier;
     private String createdDatetime;
-    private String lastModifiedDatetime;
 
     public FollowerResponse(Follow follow) {
         this.id = follow.getId();
-        this.follower = follow.getFollower().getId();
-        this.email = follow.getFollower().getEmail();
+        this.followerId = follow.getFollower().getId();
         this.nickname = follow.getFollower().getNickname();
-        this.birth = follow.getFollower().getBirth();
+        this.followerCount = follow.getFollower().getFollowCount().getFollowerCount();
+        this.followingCount = follow.getFollower().getFollowCount().getFollowingCount();
+        this.tier = follow.getFollower().getTier();
         this.createdDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getCreatedDatetime());
-        this.lastModifiedDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getLastModifiedDatetime());
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowingResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/FollowingResponse.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.users.entity.Follow;
+import site.bookmore.bookmore.users.entity.Tier;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 @Builder
@@ -15,20 +15,20 @@ import java.time.format.DateTimeFormatter;
 @NoArgsConstructor
 public class FollowingResponse {
     private Long id;
-    private Long following;
-    private String email;
+    private Long followingId;
     private String nickname;
-    private LocalDate birth;
+    private Integer followerCount;
+    private Integer followingCount;
+    private Tier tier;
     private String createdDatetime;
-    private String lastModifiedDatetime;
 
     public FollowingResponse(Follow follow) {
         this.id = follow.getId();
-        this.following = follow.getFollowing().getId();
-        this.email = follow.getFollowing().getEmail();
+        this.followingId = follow.getFollowing().getId();
         this.nickname = follow.getFollowing().getNickname();
-        this.birth = follow.getFollowing().getBirth();
+        this.followerCount = follow.getFollowing().getFollowCount().getFollowerCount();
+        this.followingCount = follow.getFollowing().getFollowCount().getFollowingCount();
+        this.tier = follow.getFollowing().getTier();
         this.createdDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getCreatedDatetime());
-        this.lastModifiedDatetime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(follow.getLastModifiedDatetime());
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/entity/FollowCount.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/entity/FollowCount.java
@@ -1,0 +1,41 @@
+package site.bookmore.bookmore.users.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class FollowCount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Integer followerCount;
+
+    private Integer followingCount;
+
+    public void plusFollowerCount(Integer followerCount) {
+        this.followerCount = followerCount + 1;
+    }
+
+    public void minusFollowerCount(Integer followerCount) {
+        this.followerCount = followerCount - 1;
+    }
+
+    public void plusFollowingCount(Integer followingCount) {
+        this.followingCount = followingCount + 1;
+    }
+
+    public void minusFollowingCount(Integer followingCount) {
+        this.followingCount = followingCount - 1;
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/users/entity/FollowCount.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/entity/FollowCount.java
@@ -9,6 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.validation.constraints.PositiveOrZero;
 
 @Entity
 @Builder
@@ -19,8 +20,11 @@ public class FollowCount {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @PositiveOrZero
     private Integer followerCount;
 
+    @PositiveOrZero
     private Integer followingCount;
 
     public void plusFollowerCount(Integer followerCount) {

--- a/backend/src/main/java/site/bookmore/bookmore/users/entity/FollowCount.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/entity/FollowCount.java
@@ -27,19 +27,19 @@ public class FollowCount {
     @PositiveOrZero
     private Integer followingCount;
 
-    public void plusFollowerCount(Integer followerCount) {
-        this.followerCount = followerCount + 1;
+    public void plusFollowerCount() {
+        this.followerCount++;
     }
 
-    public void minusFollowerCount(Integer followerCount) {
-        this.followerCount = followerCount - 1;
+    public void minusFollowerCount() {
+        this.followerCount--;
     }
 
-    public void plusFollowingCount(Integer followingCount) {
-        this.followingCount = followingCount + 1;
+    public void plusFollowingCount() {
+        this.followingCount++;
     }
 
-    public void minusFollowingCount(Integer followingCount) {
-        this.followingCount = followingCount - 1;
+    public void minusFollowingCount() {
+        this.followingCount--;
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
@@ -17,7 +17,6 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @Getter
-@Table(name = "users")
 public class User extends BaseEntity implements UserDetails {
 
     @Id

--- a/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
@@ -17,6 +17,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @Getter
+@Table(name = "users")
 public class User extends BaseEntity implements UserDetails {
 
     @Id
@@ -49,6 +50,11 @@ public class User extends BaseEntity implements UserDetails {
     @Column(nullable = false)
     private boolean enabled = true;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @JoinColumn(name = "follow_count_id")
+    private FollowCount followCount;
+
+
     @Builder
     public User(Long id, String email, String password, Role role, String nickname, Tier tier, LocalDate birth) {
         this.id = id;
@@ -58,6 +64,10 @@ public class User extends BaseEntity implements UserDetails {
         this.tier = tier;
         this.birth = birth;
         this.role = role == null ? Role.ROLE_USER : role;
+        this.followCount = FollowCount.builder()
+                .followerCount(0)
+                .followingCount(0)
+                .build();
     }
 
     public void update(User user) {

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
@@ -91,10 +91,8 @@ public class FollowService {
 
         targetFollow.delete();
 
-        if(user.getFollowCount().getFollowingCount() >= 1 && targetUser.getFollowCount().getFollowerCount() >= 1){
-            user.getFollowCount().minusFollowingCount(user.getFollowCount().getFollowingCount());
-            targetUser.getFollowCount().minusFollowerCount(targetUser.getFollowCount().getFollowerCount());
-        }
+        user.getFollowCount().minusFollowingCount(user.getFollowCount().getFollowingCount());
+        targetUser.getFollowCount().minusFollowerCount(targetUser.getFollowCount().getFollowerCount());
 
         return String.format("%s 님을 언팔로우 하셨습니다.", id);
     }

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
@@ -91,8 +91,10 @@ public class FollowService {
 
         targetFollow.delete();
 
-        user.getFollowCount().minusFollowingCount(user.getFollowCount().getFollowingCount());
-        targetUser.getFollowCount().minusFollowerCount(targetUser.getFollowCount().getFollowerCount());
+        if(user.getFollowCount().getFollowingCount() >= 1 && targetUser.getFollowCount().getFollowerCount() >= 1){
+            user.getFollowCount().minusFollowingCount(user.getFollowCount().getFollowingCount());
+            targetUser.getFollowCount().minusFollowerCount(targetUser.getFollowCount().getFollowerCount());
+        }
 
         return String.format("%s 님을 언팔로우 하셨습니다.", id);
     }

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
@@ -62,8 +62,8 @@ public class FollowService {
         follow.undelete();
         followRepository.save(follow);
 
-        user.getFollowCount().plusFollowingCount(user.getFollowCount().getFollowingCount());
-        targetUser.getFollowCount().plusFollowerCount(targetUser.getFollowCount().getFollowerCount());
+        user.getFollowCount().plusFollowingCount();
+        targetUser.getFollowCount().plusFollowerCount();
 
         publisher.publishEvent(AlarmCreate.of(AlarmType.NEW_FOLLOW, follow.getFollowing(), user, follow.getId()));
 
@@ -91,8 +91,8 @@ public class FollowService {
 
         targetFollow.delete();
 
-        user.getFollowCount().minusFollowingCount(user.getFollowCount().getFollowingCount());
-        targetUser.getFollowCount().minusFollowerCount(targetUser.getFollowCount().getFollowerCount());
+        user.getFollowCount().minusFollowingCount();
+        targetUser.getFollowCount().minusFollowerCount();
 
         return String.format("%s 님을 언팔로우 하셨습니다.", id);
     }

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/FollowService.java
@@ -21,7 +21,6 @@ import site.bookmore.bookmore.users.repositroy.FollowRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
 
 import java.util.Objects;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +30,7 @@ public class FollowService {
     private final UserRepository userRepository;
     private final ApplicationEventPublisher publisher;
 
+    @Transactional
     public String following(Long id, String email) {
 
         //나
@@ -62,6 +62,9 @@ public class FollowService {
         follow.undelete();
         followRepository.save(follow);
 
+        user.getFollowCount().plusFollowingCount(user.getFollowCount().getFollowingCount());
+        targetUser.getFollowCount().plusFollowerCount(targetUser.getFollowCount().getFollowerCount());
+
         publisher.publishEvent(AlarmCreate.of(AlarmType.NEW_FOLLOW, follow.getFollowing(), user, follow.getId()));
 
         return String.format("%s 님을 팔로우 하셨습니다.", id);
@@ -87,6 +90,9 @@ public class FollowService {
         }
 
         targetFollow.delete();
+
+        user.getFollowCount().minusFollowingCount(user.getFollowCount().getFollowingCount());
+        targetUser.getFollowCount().minusFollowerCount(targetUser.getFollowCount().getFollowerCount());
 
         return String.format("%s 님을 언팔로우 하셨습니다.", id);
     }


### PR DESCRIPTION
## 개요

- 팔로잉/팔로워 카운트 기능 추가

## 작업 내용

- FollowCount 테이블 작성 후 User와 일대일 매핑
- 팔로우 팔로잉 조회시 아래처럼 나오도록 수정
```json
{
"id": 2,
"followingId": 3,
"nickname": "yeonjae3",
"followerCount": 2,
"followingCount": 0,
"tier": null,
"createdDatetime": "2023-02-01 13:34:26"
},
```

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과

## 주안점(optional)

- 리뷰 카운트는 제외했습니다.