### PR TITLE
도서 리뷰 작성 Validation 적용

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/controller/ReviewController.java
@@ -17,6 +17,8 @@ import site.bookmore.bookmore.common.dto.ResultResponse;
 import site.bookmore.bookmore.common.support.annotation.Authorized;
 import springfox.documentation.annotations.ApiIgnore;
 
+import javax.validation.Valid;
+
 @RestController
 @Api(tags = "4-리뷰")
 @RequestMapping("/api/v1/books")
@@ -28,7 +30,7 @@ public class ReviewController {
     @Authorized
     @ApiOperation(value = "작성")
     @PostMapping("/{isbn}/reviews")
-    public ResultResponse<ReviewResponse> create(@RequestBody ReviewRequest reviewRequest, @PathVariable String isbn, Authentication authentication) {
+    public ResultResponse<ReviewResponse> create(@RequestBody @Valid ReviewRequest reviewRequest, @PathVariable String isbn, Authentication authentication) {
         String email = authentication.getName();
         Long id = reviewService.create(reviewRequest, isbn, email);
         return ResultResponse.success(new ReviewResponse(id, "리뷰 등록 완료"));

--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/ChartRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/ChartRequest.java
@@ -1,0 +1,42 @@
+package site.bookmore.bookmore.books.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.bookmore.bookmore.books.entity.Chart;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class ChartRequest {
+    @Min(value = 1, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    @Max(value = 5, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    private Integer professionalism;
+    @Min(value = 1, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    @Max(value = 5, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    private Integer fun;
+    @Min(value = 1, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    @Max(value = 5, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    private Integer readability;
+    @Min(value = 1, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    @Max(value = 5, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    private Integer collectible;
+    @Min(value = 1, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    @Max(value = 5, message = "1 ~ 5점 사이의 점수만 부여할 수 있습니다.")
+    private Integer difficulty;
+
+    public Chart toEntity() {
+        return Chart.builder()
+                .professionalism(professionalism)
+                .fun(fun)
+                .readability(readability)
+                .collectible(collectible)
+                .difficulty(difficulty)
+                .build();
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
@@ -18,7 +18,7 @@ public class ReviewRequest {
     private String body;
     private boolean spoiler;
     @Valid
-    private ChartRequest chartRequest;
+    private ChartRequest chart;
 
     // 도서 리뷰 등록
     public Review toEntity(User user, Book book) {
@@ -27,7 +27,7 @@ public class ReviewRequest {
                 .book(book)
                 .body(body)
                 .spoiler(spoiler)
-                .chart(chartRequest.toEntity())
+                .chart(chart.toEntity())
                 .likesCount(0)
                 .build();
     }
@@ -37,7 +37,7 @@ public class ReviewRequest {
         return Review.builder()
                 .body(body)
                 .spoiler(spoiler)
-                .chart(chartRequest.toEntity())
+                .chart(chart.toEntity())
                 .build();
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/books/dto/ReviewRequest.java
@@ -4,17 +4,21 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.bookmore.bookmore.books.entity.Book;
-import site.bookmore.bookmore.books.entity.Chart;
 import site.bookmore.bookmore.books.entity.Review;
 import site.bookmore.bookmore.users.entity.User;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class ReviewRequest {
+    @NotBlank(message = "본문은 반드시 작성되어야 하는 항목입니다.")
     private String body;
     private boolean spoiler;
-    private Chart chart;
+    @Valid
+    private ChartRequest chartRequest;
 
     // 도서 리뷰 등록
     public Review toEntity(User user, Book book) {
@@ -23,7 +27,7 @@ public class ReviewRequest {
                 .book(book)
                 .body(body)
                 .spoiler(spoiler)
-                .chart(chart)
+                .chart(chartRequest.toEntity())
                 .likesCount(0)
                 .build();
     }
@@ -33,7 +37,7 @@ public class ReviewRequest {
         return Review.builder()
                 .body(body)
                 .spoiler(spoiler)
-                .chart(chart)
+                .chart(chartRequest.toEntity())
                 .build();
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/common/dto/ErrorResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/dto/ErrorResponse.java
@@ -3,6 +3,8 @@ package site.bookmore.bookmore.common.dto;
 import lombok.Getter;
 import site.bookmore.bookmore.common.exception.ErrorCode;
 
+import java.util.Map;
+
 @Getter
 public class ErrorResponse {
     private final String errorCode;
@@ -13,7 +15,23 @@ public class ErrorResponse {
         this.message = errorCode.getMessage();
     }
 
+    public ErrorResponse(Map<String, String> result) {
+
+        String key = "";
+
+        for (String keys : result.keySet()) {
+            key = keys;
+        }
+
+        this.errorCode = key + " 입력값 오류";
+        this.message = result.get(key);
+    }
+
     public static ErrorResponse of(ErrorCode errorCode) {
         return new ErrorResponse(errorCode);
+    }
+
+    public static ErrorResponse of(Map<String, String> result) {
+        return new ErrorResponse(result);
     }
 }

--- a/backend/src/test/java/site/bookmore/bookmore/books/service/ReviewServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/books/service/ReviewServiceTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationEventPublisher;
+import site.bookmore.bookmore.books.dto.ChartRequest;
 import site.bookmore.bookmore.books.dto.ReviewRequest;
 import site.bookmore.bookmore.books.entity.Book;
-import site.bookmore.bookmore.books.entity.Chart;
 import site.bookmore.bookmore.books.entity.Likes;
 import site.bookmore.bookmore.books.entity.Review;
 import site.bookmore.bookmore.books.repository.BookRepository;
@@ -69,7 +69,7 @@ class ReviewServiceTest {
         when(reviewRepository.save(any(Review.class)))
                 .thenReturn(review);
 
-        Assertions.assertDoesNotThrow(() -> reviewService.create(new ReviewRequest(), book.getId(), user.getEmail()));
+        Assertions.assertDoesNotThrow(() -> reviewService.create(new ReviewRequest("body", false, new ChartRequest()), book.getId(), user.getEmail()));
     }
 
     @Test
@@ -133,7 +133,7 @@ class ReviewServiceTest {
         when(userRepository.findByEmail(user2.getEmail()))
                 .thenReturn(Optional.of(user2));
 
-        AbstractAppException abstractAppException = Assertions.assertThrows(AbstractAppException.class, () -> reviewService.update(new ReviewRequest("new body", true, new Chart()), review.getId(), user2.getEmail()));
+        AbstractAppException abstractAppException = Assertions.assertThrows(AbstractAppException.class, () -> reviewService.update(new ReviewRequest("new body", true, new ChartRequest()), review.getId(), user2.getEmail()));
         assertEquals(ErrorCode.INVALID_PERMISSION, abstractAppException.getErrorCode());
     }
 


### PR DESCRIPTION
## 개요

1. 도서 리뷰 작성에 Validation을 적용했습니다.
2. 에러 메시지 형식을 위해 exception을 수정했습니다.

## 작업 내용

- 도서 리뷰 작성에서 body는 빈 값일 수 없음
- 도서 리뷰 작성에서 chart의 5가지 값은 1 ~ 5점만을 점수로 가질 수 있음

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [x] 테스트 코드 작성 및 통과

## 주안점

- 에러 메시지 형식을 위해 공통으로 사용하는 ```GlobalExceptionHandler```와 ```ErrorResponse```를 수정했습니다. 확인 바랍니다.