### PR TITLE
프로필 사진 등록 기능 구현(AWS S3)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -60,12 +61,12 @@ jacocoTestReport {
             fileTree(
                     dir: it,
                     includes: [
-                        'site/bookmore/bookmore/**/controller/*',
-                        'site/bookmore/bookmore/**/service/*',
+                            'site/bookmore/bookmore/**/controller/*',
+                            'site/bookmore/bookmore/**/service/*',
                     ],
                     excludes: [
-                        'site/bookmore/bookmore/common/*'
-            ])
+                            'site/bookmore/bookmore/common/*'
+                    ])
         }))
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/ErrorCode.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/ErrorCode.java
@@ -7,7 +7,7 @@ import static org.springframework.http.HttpStatus.*;
 public enum ErrorCode {
     INVALID_PASSWORD(UNAUTHORIZED, "잘못된 패스워드입니다."),
     INVALID_TOKEN(UNAUTHORIZED, "잘못된 토큰입니다."),
-    USER_NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+    USER_NOT_LOGGED_IN(UNAUTHORIZED, "로그인이 필요합니다."),
     INVALID_PERMISSION(FORBIDDEN, "권한이 없습니다."),
     USER_NOT_FOUND(NOT_FOUND, "해당하는 유저를 찾을 수 없습니다."),
     EMAIL_NOT_FOUND(NOT_FOUND, "해당하는 이메일을 찾을 수 없습니다."),
@@ -17,9 +17,12 @@ public enum ErrorCode {
     FOLLOW_NOT_FOUND(NOT_FOUND, "팔로우 중이 아닙니다."),
     API_REQUEST_TIMEOUT(REQUEST_TIMEOUT, "요청 시간이 초과되었습니다."),
     DUPLICATED_NICKNAME(CONFLICT, "이미 사용중인 닉네임입니다."),
+    DUPLICATED_PROFILE(CONFLICT, "프로필이 이미 기본 사진입니다."),
     DUPLICATED_EMAIL(CONFLICT, "이미 사용중인 이메일입니다."),
     DUPLICATED_FOLLOW(CONFLICT, "이미 팔로우 중입니다."),
     FOLLOW_NOT_ME(BAD_REQUEST, "나를 팔로우 할 수 없습니다."),
+    FILE_NOT_EXISTS(BAD_REQUEST, "파일이 첨부되지 않았습니다."),
+    FILE_SIZE_EXCEED(BAD_REQUEST, "업로드 가능한 파일 용량을 초과했습니다."),
     DATABASE_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 에러");
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import site.bookmore.bookmore.common.dto.ErrorResponse;
 import site.bookmore.bookmore.common.dto.ResultResponse;
 
@@ -18,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static site.bookmore.bookmore.common.exception.ErrorCode.DATABASE_ERROR;
+import static site.bookmore.bookmore.common.exception.ErrorCode.FILE_SIZE_EXCEED;
 
 @Slf4j
 @RestControllerAdvice
@@ -74,5 +76,12 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ResultResponse.error(ErrorResponse.of(result)));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<?> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.info("handleMaxUploadSizeExceededException", e);
+        return ResponseEntity.status(FILE_SIZE_EXCEED.getHttpStatus())
+                .body(ResultResponse.error(ErrorResponse.of(FILE_SIZE_EXCEED)));
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/bad_request/FileNotExistsException.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/bad_request/FileNotExistsException.java
@@ -1,0 +1,11 @@
+package site.bookmore.bookmore.common.exception.bad_request;
+
+import site.bookmore.bookmore.common.exception.AbstractAppException;
+
+import static site.bookmore.bookmore.common.exception.ErrorCode.FILE_NOT_EXISTS;
+
+public class FileNotExistsException extends AbstractAppException {
+    public FileNotExistsException() {
+        super(FILE_NOT_EXISTS);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/common/exception/conflict/DuplicateProfileException.java
+++ b/backend/src/main/java/site/bookmore/bookmore/common/exception/conflict/DuplicateProfileException.java
@@ -1,0 +1,11 @@
+package site.bookmore.bookmore.common.exception.conflict;
+
+import site.bookmore.bookmore.common.exception.AbstractAppException;
+
+import static site.bookmore.bookmore.common.exception.ErrorCode.DUPLICATED_PROFILE;
+
+public class DuplicateProfileException extends AbstractAppException {
+    public DuplicateProfileException() {
+        super(DUPLICATED_PROFILE);
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/s3/AwsS3Uploader.java
+++ b/backend/src/main/java/site/bookmore/bookmore/s3/AwsS3Uploader.java
@@ -1,0 +1,60 @@
+package site.bookmore.bookmore.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.http.fileupload.FileUploadException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import site.bookmore.bookmore.common.exception.bad_request.FileNotExistsException;
+import site.bookmore.bookmore.users.entity.User;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class AwsS3Uploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile multipartFile) throws IOException {
+        if (multipartFile.isEmpty()) {
+            throw new FileNotExistsException();
+        }
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType((multipartFile.getContentType()));
+        objectMetadata.setContentLength(multipartFile.getSize());
+
+        String originalFileName = multipartFile.getOriginalFilename();
+        int index = originalFileName.lastIndexOf(".");
+        String ext = originalFileName.substring(index + 1); // 확장자
+
+        String storedFileName = UUID.randomUUID() + "." + ext;
+
+        String key = "images/" + storedFileName;
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new FileUploadException();
+        }
+
+        return key;
+    }
+
+    public void delete(User user) {
+
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, user.getProfile()));
+    }
+}

--- a/backend/src/main/java/site/bookmore/bookmore/s3/AwsS3Uploader.java
+++ b/backend/src/main/java/site/bookmore/bookmore/s3/AwsS3Uploader.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import site.bookmore.bookmore.common.exception.bad_request.FileNotExistsException;
-import site.bookmore.bookmore.users.entity.User;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,8 +52,8 @@ public class AwsS3Uploader {
         return key;
     }
 
-    public void delete(User user) {
+    public void delete(String filePath) {
 
-        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, user.getProfile()));
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, filePath));
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/controller/UserController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import site.bookmore.bookmore.common.dto.ResultResponse;
 import site.bookmore.bookmore.common.support.annotation.Authorized;
 import site.bookmore.bookmore.users.dto.*;
@@ -12,6 +13,7 @@ import site.bookmore.bookmore.users.service.UserService;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
+import java.io.IOException;
 
 @RestController
 @Api(tags = "1-회원")
@@ -20,6 +22,7 @@ import javax.validation.Valid;
 public class UserController {
 
     private final UserService userService;
+
 
     @ApiOperation(value = "회원가입")
     @PostMapping("/join")
@@ -64,5 +67,23 @@ public class UserController {
     @GetMapping("/{id}")
     public ResultResponse<UserDetailResponse> detail(@PathVariable Long id) {
         return ResultResponse.success(userService.detail(id));
+    }
+
+    @Authorized
+    @ApiOperation(value = "회원 프로필 사진 변경")
+    @PostMapping("/me/profile")
+    public ResultResponse<UserProfileResponse> updateProfile(@RequestPart MultipartFile multipartFile, Authentication authentication) throws IOException {
+        String email = authentication.getName();
+        String userNickname = userService.updateProfile(multipartFile, email);
+        return ResultResponse.success(new UserProfileResponse(userNickname, "프로필 사진 변경 완료"));
+    }
+
+    @Authorized
+    @ApiOperation(value = "회원 프로필 기본 사진으로 변경")
+    @DeleteMapping("/me/profile")
+    public ResultResponse<UserProfileResponse> updateProfileDefault(Authentication authentication) {
+        String email = authentication.getName();
+        String userNickname = userService.updateProfileDefault(email);
+        return ResultResponse.success(new UserProfileResponse(userNickname, "프로필 기본 사진으로 변경 완료"));
     }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/UserProfileResponse.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/UserProfileResponse.java
@@ -1,0 +1,15 @@
+package site.bookmore.bookmore.users.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfileResponse {
+    private String nickname;
+    private String message;
+}

--- a/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/entity/User.java
@@ -19,6 +19,8 @@ import java.util.List;
 @Getter
 public class User extends BaseEntity implements UserDetails {
 
+    public static final String DEFAULT_PROFILE_IMG_PATH = "images/default-profile.png";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -56,6 +58,8 @@ public class User extends BaseEntity implements UserDetails {
     public User(String email) {
         this.email = email;
     }
+
+    private String profile = DEFAULT_PROFILE_IMG_PATH;
 
     @Builder
     public User(Long id, String email, String password, Role role, String nickname, Tier tier, LocalDate birth) {
@@ -96,6 +100,23 @@ public class User extends BaseEntity implements UserDetails {
         }
     }
 
+    public void updateProfile(String profile) {
+        setProfile(profile);
+    }
+
+    private void setProfile(String profile) {
+        if (profile != null) {
+            this.profile = profile;
+        }
+    }
+
+    public void updateProfileDefault() {
+        setProfileDefault();
+    }
+
+    private void setProfileDefault() {
+        this.profile = DEFAULT_PROFILE_IMG_PATH;
+    }
 
     //권한을 리턴
     @Override
@@ -104,7 +125,7 @@ public class User extends BaseEntity implements UserDetails {
     }
 
 
-    // 사용자의 password를 반환
+    // 사용자의 password 를 반환
     @Override
     public String getPassword() {
         return this.password;

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
@@ -14,6 +14,7 @@ import site.bookmore.bookmore.common.exception.conflict.DuplicateProfileExceptio
 import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
 import site.bookmore.bookmore.common.exception.unauthorized.InvalidPasswordException;
 import site.bookmore.bookmore.common.exception.unauthorized.InvalidTokenException;
+import site.bookmore.bookmore.s3.AwsS3Uploader;
 import site.bookmore.bookmore.security.provider.JwtProvider;
 import site.bookmore.bookmore.users.dto.*;
 import site.bookmore.bookmore.users.entity.Ranks;
@@ -21,7 +22,6 @@ import site.bookmore.bookmore.users.entity.Role;
 import site.bookmore.bookmore.users.entity.User;
 import site.bookmore.bookmore.users.repositroy.RanksRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
-import site.bookmore.bookmore.s3.AwsS3Uploader;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -167,7 +167,7 @@ public class UserService implements UserDetailsService {
             throw new DuplicateProfileException();
         }
 
-        awsS3Uploader.delete(user);
+        awsS3Uploader.delete(user.getProfile());
 
         user.updateProfileDefault();
         return user.getNickname();

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
@@ -7,8 +7,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateEmailException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateNicknameException;
+import site.bookmore.bookmore.common.exception.conflict.DuplicateProfileException;
 import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
 import site.bookmore.bookmore.common.exception.unauthorized.InvalidPasswordException;
 import site.bookmore.bookmore.common.exception.unauthorized.InvalidTokenException;
@@ -19,6 +21,12 @@ import site.bookmore.bookmore.users.entity.Role;
 import site.bookmore.bookmore.users.entity.User;
 import site.bookmore.bookmore.users.repositroy.RanksRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
+import site.bookmore.bookmore.s3.AwsS3Uploader;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static site.bookmore.bookmore.users.entity.User.DEFAULT_PROFILE_IMG_PATH;
 
 
 @RequiredArgsConstructor
@@ -29,6 +37,7 @@ public class UserService implements UserDetailsService {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final RanksRepository ranksRepository;
+    private final AwsS3Uploader awsS3Uploader;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
@@ -136,4 +145,31 @@ public class UserService implements UserDetailsService {
                 .build();
     }
 
+    @Transactional
+    public String updateProfile(MultipartFile multipartFile, String email) throws IOException {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        String key = awsS3Uploader.upload(multipartFile);
+
+        user.updateProfile(key);
+        return user.getNickname();
+    }
+
+    @Transactional
+    public String updateProfileDefault(String email) {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (Objects.equals(user.getProfile(), DEFAULT_PROFILE_IMG_PATH)) {
+            throw new DuplicateProfileException();
+        }
+
+        awsS3Uploader.delete(user);
+
+        user.updateProfileDefault();
+        return user.getNickname();
+    }
 }

--- a/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import site.bookmore.bookmore.users.dto.UserUpdateRequest;
 import site.bookmore.bookmore.users.entity.User;
 import site.bookmore.bookmore.users.repositroy.RanksRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
+import site.bookmore.bookmore.s3.AwsS3Uploader;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -38,8 +39,9 @@ class UserServiceTest {
     private final JwtProvider jwtProvider = mock(JwtProvider.class);
 
     private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+    private final AwsS3Uploader awsS3Uploader = mock(AwsS3Uploader.class);
 
-    private final UserService userService = new UserService(passwordEncoder, jwtProvider, userRepository, ranksRepository);
+    private final UserService userService = new UserService(passwordEncoder, jwtProvider, userRepository, ranksRepository, awsS3Uploader);
 
     private final User user = User.builder()
             .id(0L)


### PR DESCRIPTION
## 개요

SpringBoot와 AWS S3을 연동하여 회원 프로필 사진 등록 기능을 구현했습니다.

## 작업 내용

- user entity에 profile 컬럼 추가(default 프로필로 설정)
- 기능1: 사용자가 첨부하는 프로필로 변경
  - 첨부파일이 없거나, 용량이 3MB 초과 시 예외 발생  
- 기능2: 기본 프로필로 변경 
  - 이미 기본 프로필이면 예외 발생 
- controller - service - uploader 레이어 분리

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [ ] 테스트 코드 작성 및 통과