### PR TITLE
태그 수정, 탈퇴한 유저 로그인되는 이슈, 패스워드 수정 이슈 해결

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/reviews/dto/ReviewRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/reviews/dto/ReviewRequest.java
@@ -9,7 +9,6 @@ import site.bookmore.bookmore.users.entity.User;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import java.util.HashSet;
 import java.util.Set;
 
 @AllArgsConstructor
@@ -21,7 +20,7 @@ public class ReviewRequest {
     private boolean spoiler;
     @Valid
     private ChartRequest chart;
-    private Set<String> tags = new HashSet<>();
+    private Set<String> tags;
 
     // 도서 리뷰 등록
     public Review toEntity(User user, Book book) {

--- a/backend/src/main/java/site/bookmore/bookmore/reviews/service/ReviewService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/reviews/service/ReviewService.java
@@ -64,7 +64,7 @@ public class ReviewService {
 
         Set<String> tagsLabel = reviewRequest.getTags();
 
-        if (tagsLabel.isEmpty()) {
+        if (tagsLabel == null || tagsLabel.isEmpty()) {
             // 나의 팔로잉이 리뷰를 등록했을 때의 알림 발생
             List<Follow> follows = followRepository.findAllByFollowingAndDeletedDatetimeIsNull(user);
             List<User> followers = follows.stream().map(Follow::getFollower).collect(Collectors.toList());
@@ -114,7 +114,7 @@ public class ReviewService {
 
         review.update(reviewRequest.toEntity());
 
-        if (updateTagsLabel.isEmpty()) return review.getId();
+        if (updateTagsLabel == null) return review.getId();
 
         Set<Tag> oldTags = review.getTags();
 

--- a/backend/src/main/java/site/bookmore/bookmore/users/dto/UserUpdateRequest.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/dto/UserUpdateRequest.java
@@ -29,4 +29,11 @@ public class UserUpdateRequest {
                 .build();
     }
 
+    public User toEntity() {
+        return User.builder()
+                .password(password)
+                .nickname(nickname)
+                .birth(birth)
+                .build();
+    }
 }

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
@@ -113,13 +113,11 @@ public class UserService implements UserDetailsService {
         }
 
         // password encode
-        String encoded = userUpdateRequest.getPassword();
-        if (encoded == null) {
-            encoded = user.getPassword();
-        }
-        String encodedPw = passwordEncoder.encode(encoded);
+        String password = userUpdateRequest.getPassword();
 
-        user.update(userUpdateRequest.toEntity(encodedPw));
+        User updated = password == null ? userUpdateRequest.toEntity() : userUpdateRequest.toEntity(passwordEncoder.encode(password));
+
+        user.update(updated);
 
         return UserResponse.of(user, "수정 완료 했습니다.");
     }

--- a/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/users/service/UserService.java
@@ -84,7 +84,7 @@ public class UserService implements UserDetailsService {
      * 로그인
      */
     public UserLoginResponse login(UserLoginRequest userLoginRequest) {
-        User user = userRepository.findByEmail(userLoginRequest.getEmail()).orElseThrow(UserNotFoundException::new);
+        User user = userRepository.findByEmailAndDeletedDatetimeIsNull(userLoginRequest.getEmail()).orElseThrow(UserNotFoundException::new);
         if (!user.isEnabled() && user.getDeletedDatetime() != null) throw new AlreadyDeletedUserException();
         if (!passwordEncoder.matches(userLoginRequest.getPassword(), user.getPassword()))
             throw new InvalidPasswordException();

--- a/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
@@ -10,6 +10,7 @@ import site.bookmore.bookmore.common.exception.conflict.DuplicateNicknameExcepti
 import site.bookmore.bookmore.common.exception.not_found.UserNotFoundException;
 import site.bookmore.bookmore.common.exception.unauthorized.InvalidPasswordException;
 import site.bookmore.bookmore.common.exception.unauthorized.InvalidTokenException;
+import site.bookmore.bookmore.s3.AwsS3Uploader;
 import site.bookmore.bookmore.security.provider.JwtProvider;
 import site.bookmore.bookmore.users.dto.UserJoinRequest;
 import site.bookmore.bookmore.users.dto.UserLoginRequest;
@@ -19,7 +20,6 @@ import site.bookmore.bookmore.users.entity.User;
 import site.bookmore.bookmore.users.repositroy.FollowRepository;
 import site.bookmore.bookmore.users.repositroy.RanksRepository;
 import site.bookmore.bookmore.users.repositroy.UserRepository;
-import site.bookmore.bookmore.s3.AwsS3Uploader;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -104,7 +104,7 @@ class UserServiceTest {
     @Test
     @DisplayName("로그인 - 성공")
     void login_success() {
-        when(userRepository.findByEmail(user.getEmail()))
+        when(userRepository.findByEmailAndDeletedDatetimeIsNull(user.getEmail()))
                 .thenReturn(Optional.of(user));
 
         when(!passwordEncoder.matches(user.getPassword(), "password"))
@@ -129,7 +129,7 @@ class UserServiceTest {
     @Test
     @DisplayName("로그인 - 실패(비밀번호 틀림)")
     void login_fail_2() {
-        when(userRepository.findByEmail(user.getEmail()))
+        when(userRepository.findByEmailAndDeletedDatetimeIsNull(user.getEmail()))
                 .thenReturn(Optional.of(user));
 
         when(!passwordEncoder.matches(user.getPassword(), "password"))


### PR DESCRIPTION
## 개요

- 태그 수정 이슈 해결
- 탈퇴한 유저가 로그인이 되는 이슈 해결
- 패스워드 수정 이슈 해결

## 작업 내용

- 태그 수정 시 null값과 빈 리스트를 구분하도록 수정하였습니다.
- 탈퇴한 유저가 로그인되는 버그를 수정하였습니다.
- 패스워드 수정 시 수정 요청 값이 null이어도 변경되는 이슈를 수정하였습니다.