### PR TITLE
회원 탈퇴 시, 알림 처리

### DIFF
--- a/backend/src/main/java/site/bookmore/bookmore/alarms/entity/Alarm.java
+++ b/backend/src/main/java/site/bookmore/bookmore/alarms/entity/Alarm.java
@@ -4,12 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import site.bookmore.bookmore.common.entity.BaseEntity;
 import site.bookmore.bookmore.users.entity.User;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "alarm")
@@ -18,7 +17,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Alarm {
+public class Alarm extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,10 +31,6 @@ public class Alarm {
 
     @Column(nullable = false)
     private boolean confirmed;
-
-    @CreatedDate
-    @Column(name = "created_datetime")
-    private LocalDateTime createdDatetime;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "target_user", nullable = false, foreignKey = @ForeignKey(name = "fk_alarm_target_user"))

--- a/backend/src/main/java/site/bookmore/bookmore/alarms/repository/AlarmRepository.java
+++ b/backend/src/main/java/site/bookmore/bookmore/alarms/repository/AlarmRepository.java
@@ -6,7 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import site.bookmore.bookmore.alarms.entity.Alarm;
 import site.bookmore.bookmore.users.entity.User;
 
+import java.util.List;
+
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
-    Page<Alarm> findByTargetUser(User target, Pageable pageable);
-    Page<Alarm> findByTargetUserAndConfirmedIsFalse(User target, Pageable pageable);
+    Page<Alarm> findByTargetUserAndDeletedDatetimeIsNull(User target, Pageable pageable);
+
+    Page<Alarm> findByTargetUserAndConfirmedIsFalseAndDeletedDatetimeIsNull(User target, Pageable pageable);
+
+    List<Alarm> findByTargetUser(User fromUser);
 }

--- a/backend/src/main/java/site/bookmore/bookmore/alarms/service/AlarmService.java
+++ b/backend/src/main/java/site/bookmore/bookmore/alarms/service/AlarmService.java
@@ -35,7 +35,7 @@ public class AlarmService {
      */
     public Page<AlarmResponse> findByFollowingReview(Pageable pageable, String email) {
         User target = userRepository.findByEmailAndDeletedDatetimeIsNull(email).orElseThrow(UserNotFoundException::new);
-        return alarmRepository.findByTargetUser(target, pageable).map(getAlarmResponse());
+        return alarmRepository.findByTargetUserAndDeletedDatetimeIsNull(target, pageable).map(getAlarmResponse());
     }
 
     /**
@@ -43,7 +43,7 @@ public class AlarmService {
      */
     public Page<AlarmResponse> getNewAlarms(Pageable pageable, String email) {
         User target = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
-        return alarmRepository.findByTargetUserAndConfirmedIsFalse(target, pageable).map(getAlarmResponse());
+        return alarmRepository.findByTargetUserAndConfirmedIsFalseAndDeletedDatetimeIsNull(target, pageable).map(getAlarmResponse());
     }
 
     @Transactional

--- a/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
+++ b/backend/src/test/java/site/bookmore/bookmore/users/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import site.bookmore.bookmore.alarms.repository.AlarmRepository;
 import site.bookmore.bookmore.common.exception.AbstractAppException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateEmailException;
 import site.bookmore.bookmore.common.exception.conflict.DuplicateNicknameException;
@@ -43,8 +44,9 @@ class UserServiceTest {
 
     private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
     private final AwsS3Uploader awsS3Uploader = mock(AwsS3Uploader.class);
+    private final AlarmRepository alarmRepository = mock(AlarmRepository.class);
 
-    private final UserService userService = new UserService(passwordEncoder, jwtProvider, userRepository, ranksRepository, followRepository, awsS3Uploader);
+    private final UserService userService = new UserService(passwordEncoder, jwtProvider, userRepository, ranksRepository, followRepository, awsS3Uploader, alarmRepository);
 
     private final User user = User.builder()
             .id(0L)


### PR DESCRIPTION
## 개요

```NEW_FOLLOW```알림에 한해 회원 탈퇴 시 알림 삭제

## 작업 내용

- 회원 탈퇴 시, 탈퇴하는 회원이 받은 알림을 리스트로 받고 for문으로 알림 타입을 확인하여 ```NEW_FOLLOW``` 타입의 알림만 삭제하였습니다.
- 삭제 컬럼을 위해 Alarm 엔티티가 BaseEntity를 상속받도록 수정하였습니다.
- 삭제 컬럼의 추가로 기존의 모든 알림 조회 및 새로운 알림 조회 기능이 삭제된 알림은 제외하고 조회하도록 수정하였습니다.

## 체크리스트

- [x] 코드 포맷팅 확인
- [x] 불필요한 import 제거
- [ ] 테스트 코드 작성 및 통과